### PR TITLE
Rework shared indexes metrics

### DIFF
--- a/dashboard/src/report/InputForm.vue
+++ b/dashboard/src/report/InputForm.vue
@@ -4,7 +4,7 @@
     <el-col :span="10">
       <el-input
         type="textarea"
-        :rows="4"
+        :rows="30"
         placeholder="Enter the IntelliJ Platform start-up timeline..."
         @input="inputChanged"
         v-model="inputData">

--- a/db-schema/sharedIndexes/report.sql
+++ b/db-schema/sharedIndexes/report.sql
@@ -18,3 +18,48 @@ create table report
     partition by (toYYYYMM(generated_time))
     order by (machine, branch, project, build_c1, build_c2, build_c3, build_time, generated_time)
     settings old_parts_lifetime = 10;
+
+-- View for metric descriptors.
+--
+-- <metric_name>         <metric_type>
+-- indexing                  d
+-- scanning                  d
+-- numberOfIndexedFiles      c
+-- etc
+create or replace view metric_descriptors as
+select tuple.1 as metric_name, tuple.2 as metric_type
+from (
+      select distinct arrayJoin(
+                        arrayMap(
+                          o -> (JSONExtractString(o, 'n'),
+                                if(JSONHas(o, 'd'), 'd',
+                                   if(JSONHas(o, 'c'), 'c',
+                                      if(JSONHas(o, 'i'), 'i', 'd'))
+                                  )
+                            ),
+                          JSONExtractArrayRaw(raw_report, 'metrics')
+                          )
+                        ) as tuple
+      from report
+       );
+
+-- Metric values table
+-- generated_time metric_name metric_type value
+--
+-- generated_time is used as the primary key for the 'report' table
+create or replace view metric_values as
+select generated_time,
+       metric_name,
+       metric_type,
+       arrayExists(o -> JSONExtractString(o, 'n') = metric_name and JSONHas(o, metric_type), metric_array)   as exists,
+       JSONExtractInt(arrayFirst(it -> JSONExtractString(it, 'n') = metric_name, metric_array), metric_type) as metric_value
+from metric_descriptors
+       cross join (select generated_time, JSONExtractArrayRaw(raw_report, 'metrics') as metric_array from report) as all_metrics
+where exists;
+
+-- Metrics table inheriting all fields of the 'report' table.
+create or replace view metrics as
+select *
+from metric_values
+       join report
+            on metric_values.generated_time = report.generated_time;

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -167,6 +167,8 @@ func (t *StatsServer) computeMetricsResponse(query data_query.DataQuery, jsonWri
           jsonWriter.DL(int64(untypedValue))
         case int64:
           jsonWriter.DL(untypedValue)
+        case string:
+          jsonWriter.S(`"` + untypedValue + `"`)
         default:
           return errors.Errorf("unknown type: %T for field %s", untypedValue, field.Name)
         }

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -47,7 +47,11 @@ func (t *StatsServer) handleMetricsRequest(request *http.Request) ([]byte, error
 }
 
 func (t *StatsServer) computeMetricsResponse(query data_query.DataQuery, jsonWriter *quicktemplate.QWriter, context context.Context) error {
-  rows, fieldCount, err := data_query.SelectRows(query, "report", t, context)
+  table := "report"
+  if query.Database == "sharedIndexes" {
+    table = "metrics"
+  }
+  rows, fieldCount, err := data_query.SelectRows(query, table, t, context)
   if err != nil {
     return errors.WithStack(err)
   }


### PR DESCRIPTION
Database requests only on `report` table are not enough to implement requests for sharedIndexes, which may need to request arbitrary metrics. So, create helper tables where metrics are available explicitly.

For example,
```
<metric name>         <metric type>     <metric value>    *<report_fields>    
'indexing'               'd'           10421                ....<all fields from report table>
'anotherMetric'           'c'                    135                ....<all fields from report table>
```