### PR TITLE
K1 vs. K2 comparison dashboard: Improve rendering of missing results

### DIFF
--- a/dashboard/new-dashboard/src/components/common/TestComparisonTableEntry.ts
+++ b/dashboard/new-dashboard/src/components/common/TestComparisonTableEntry.ts
@@ -1,0 +1,15 @@
+/**
+ * Sometimes test results only exist for the baseline or current test, which leads to invalid table entries. A valid entry has existing
+ * baseline and current results (if both exist, the difference will also exist). An invalid entry will still be shown in the table for
+ * transparency, but its missing values will be replaced with "N/A".
+ */
+export interface TestComparisonTableEntry {
+  test: string
+  baselineValue: number | null
+  currentValue: number | null
+  difference: number | null
+}
+
+export function isValidTestComparisonTableEntry(entry: TestComparisonTableEntry) {
+  return entry.baselineValue !== null && entry.currentValue !== null && entry.difference !== null
+}

--- a/dashboard/new-dashboard/src/components/kotlin/dev/K1VsK2ComparisonTable.vue
+++ b/dashboard/new-dashboard/src/components/kotlin/dev/K1VsK2ComparisonTable.vue
@@ -27,7 +27,7 @@
       @update:result-data="(newValue) => (resultData = newValue)"
     />
 
-    <p class="text-sm text-gray-500 text-right mt-4">The table only displays the results of the last build from the selected branch.</p>
+    <p class="text-sm text-gray-500 text-right mt-4">The table displays the results of the last successful run of each test from the selected branch.</p>
   </section>
 </template>
 
@@ -37,7 +37,7 @@ import { FilterConfigurator } from "../../../configurators/filter"
 import TestComparisonTable, { TestComparison } from "../../common/TestComparisonTable.vue"
 import { DataQueryConfigurator } from "../../common/dataQuery"
 import { formatPercentage, getValueFormatterByMeasureName } from "../../common/formatter"
-import { TestComparisonTableEntry } from "../../common/TestComparisonTableEntry"
+import { isValidTestComparisonTableEntry, TestComparisonTableEntry } from "../../common/TestComparisonTableEntry"
 
 interface Props {
   name: string
@@ -59,13 +59,8 @@ const totalTimeK2 = computed(() => calculateTotalTime((entry) => entry.currentVa
 
 const totalImprovement = computed(() => (totalTimeK2.value == 0 ? 0 : (totalTimeK1.value - totalTimeK2.value) / totalTimeK2.value))
 
-function calculateTotalTime(getTime: (entry: TestComparisonTableEntry) => number): number {
-  return resultData.value
-    .map((entry) => {
-      const value = getTime(entry)
-      return Number.isFinite(value) ? value : 0
-    })
-    .reduce((a, b) => a + b, 0)
+function calculateTotalTime(getTime: (entry: TestComparisonTableEntry) => number | null): number {
+  return resultData.value.map((entry) => (isValidTestComparisonTableEntry(entry) ? (getTime(entry) as number) : 0)).reduce((a, b) => a + b, 0)
 }
 
 const topStats = computed(() => [

--- a/dashboard/new-dashboard/src/components/kotlin/dev/K1VsK2ComparisonTable.vue
+++ b/dashboard/new-dashboard/src/components/kotlin/dev/K1VsK2ComparisonTable.vue
@@ -34,9 +34,10 @@
 <script setup lang="ts">
 import { computed, Ref, ref } from "vue"
 import { FilterConfigurator } from "../../../configurators/filter"
-import TestComparisonTable, { TestComparison, TestComparisonTableEntry } from "../../common/TestComparisonTable.vue"
+import TestComparisonTable, { TestComparison } from "../../common/TestComparisonTable.vue"
 import { DataQueryConfigurator } from "../../common/dataQuery"
 import { formatPercentage, getValueFormatterByMeasureName } from "../../common/formatter"
+import { TestComparisonTableEntry } from "../../common/TestComparisonTableEntry"
 
 interface Props {
   name: string


### PR DESCRIPTION
This PR improves the handling of missing results in K1 vs. K2 comparison dashboard table entries and aggregate stats.

Especially aggregate stats suffered from missing results. For example, if a K1 test didn't produce a result but the K2 test did, the aggregate time for K2 would include the test result, while the aggregate time for K1 wouldn't (the test result would be 0ms). Thus, numbers would be skewed in favour of K1. (Or vice versa.)
