### PR TITLE
Update measure metric in Indexed Files charts

### DIFF
--- a/dashboard/new-dashboard/src/components/charts/GroupProjectsChart.vue
+++ b/dashboard/new-dashboard/src/components/charts/GroupProjectsChart.vue
@@ -47,7 +47,8 @@ watch(
   () => [props.projects, props.aliases],
   ([projects, aliases]) => {
     if (projects != null) {
-      scenarioConfigurator.aliases = aliases ?? removeCommonSegments(projects)
+      const aliasesToUse = aliases ?? removeCommonSegments(projects)
+      scenarioConfigurator.aliases = new Map(projects.map((key, index) => [key, aliasesToUse[index]]))
     }
     scenarioConfigurator.selected.value = projects
   },

--- a/dashboard/new-dashboard/src/components/common/sideBar/InfoSidebar.vue
+++ b/dashboard/new-dashboard/src/components/common/sideBar/InfoSidebar.vue
@@ -151,9 +151,8 @@
 
       <div class="flex gap-4 text-blue-500">
         <a
-          :href="data?.changesUrl"
-          target="_blank"
-          class="flex gap-1.5 items-center transition duration-150 ease-out hover:text-blue-600"
+          class="flex gap-1.5 items-center transition duration-150 ease-out hover:text-blue-600 cursor-pointer"
+          @click="getChangesUrl"
         >
           <ArrowPathIcon class="w-4 h-4" />
           Changes
@@ -400,6 +399,23 @@ function getTestActions(): {
     }
   }
   return actions
+}
+
+function getChangesUrl() {
+  if (serverConfigurator?.table == null) {
+    window.open(vm.data.value?.changesUrl)
+  } else if (vm.data.value?.installerId ?? vm.data.value?.buildId) {
+    const db = serverConfigurator.db
+    if (db == "perfint" || db == "perfintDev") {
+      getTeamcityBuildType(db, serverConfigurator.table, vm.data.value.buildId, (type: string | null) => {
+        if (vm.data.value) {
+          window.open(`${tcUrl}buildConfiguration/${type}/${vm.data.value.buildId}?buildTab=changes`)
+        }
+      })
+    } else {
+      window.open(vm.data.value.changesUrl)
+    }
+  }
 }
 
 function getArtifactsUrl() {

--- a/dashboard/new-dashboard/src/components/common/sideBar/InfoSidebarPerformance.ts
+++ b/dashboard/new-dashboard/src/components/common/sideBar/InfoSidebarPerformance.ts
@@ -112,7 +112,7 @@ function getInfo(params: CallbackDataParams, valueUnit: ValueUnit, dbType: DBTyp
     console.error("Unknown type of DB")
   }
   const fullBuildId = buildVersion == undefined ? buildNumber : `${buildVersion}.${buildNum1}${buildNum2 == 0 ? "" : `.${buildNum2}`}`
-  const changesUrl = installerId == undefined ? `${buildUrl(buildId as number)}&tab=changes` : `${buildUrl(installerId)}&tab=changes`
+  const changesUrl = installerId == undefined ? `${buildUrl(buildId as number)}&buildTab=changes` : `${buildUrl(installerId)}&buildTab=changes`
   const artifactsUrl = `${buildUrl(buildId as number)}&tab=artifacts`
   const installerUrl = installerId == undefined ? undefined : `${buildUrl(installerId)}&tab=artifacts`
   const filteredAccidents = computed(() => {

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -51,8 +51,6 @@
 </template>
 
 
-
-//processingTime#Go
 <script setup lang="ts">
 import GroupProjectsChart from "../charts/GroupProjectsChart.vue"
 import DashboardPage from "../common/DashboardPage.vue"

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -47,6 +47,27 @@
         :projects="['kubernetes/indexing', 'flux/indexing', 'istio/indexing']"
       />
     </section>
+    <section>
+      <GroupProjectsChart
+        label="Number Of Indexed Files - second IDE run"
+        measure="processingTime#Go"
+        :projects="[
+          'kubernetes/secondScanning',
+          'flux/secondScanning',
+          'istio/secondScanning',
+          'cockroach/secondScanning',
+          'delve/secondScanning',
+          'mattermost-server/secondScanning',
+        ]"
+      />
+    </section>
+    <section>
+      <GroupProjectsChart
+        label="Number Of Indexed Files - third IDE run"
+        measure="processingTime#Go"
+        :projects="['kubernetes/thirdScanning', 'flux/thirdScanning', 'istio/thirdScanning', 'cockroach/thirdScanning', 'delve/thirdScanning', 'mattermost-server/thirdScanning']"
+      />
+    </section>
   </DashboardPage>
 </template>
 

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -22,35 +22,37 @@
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files: light projects"
-        measure="numberOfIndexedFiles"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="['cockroach/indexing', 'delve/indexing', 'mattermost-server/indexing']"
       />
     </section>
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files: heavy projects"
-        measure="numberOfIndexedFiles"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="['kubernetes/indexing', 'flux/indexing', 'istio/indexing']"
       />
     </section>
-
     <section>
       <GroupProjectsChart
-        label="Number Of Runs Of Indexing: light projects"
-        measure="numberOfRunsOfIndexing"
+        label="Processing time for GO files: light projects"
+        measure="processingTime#Go"
         :projects="['cockroach/indexing', 'delve/indexing', 'mattermost-server/indexing']"
       />
     </section>
     <section>
       <GroupProjectsChart
-        label="Number Of Runs Of Indexing: heavy projects"
-        measure="numberOfRunsOfIndexing"
+        label="Processing time for GO files: heavy projects"
+        measure="processingTime#Go"
         :projects="['kubernetes/indexing', 'flux/indexing', 'istio/indexing']"
       />
     </section>
   </DashboardPage>
 </template>
 
+
+
+//processingTime#Go
 <script setup lang="ts">
 import GroupProjectsChart from "../charts/GroupProjectsChart.vue"
 import DashboardPage from "../common/DashboardPage.vue"

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -71,6 +71,9 @@
   </DashboardPage>
 </template>
 
+
+
+//processingTime#Go
 <script setup lang="ts">
 import GroupProjectsChart from "../charts/GroupProjectsChart.vue"
 import DashboardPage from "../common/DashboardPage.vue"

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -50,7 +50,6 @@
   </DashboardPage>
 </template>
 
-
 <script setup lang="ts">
 import GroupProjectsChart from "../charts/GroupProjectsChart.vue"
 import DashboardPage from "../common/DashboardPage.vue"

--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -50,7 +50,7 @@
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files - second IDE run"
-        measure="processingTime#Go"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="[
           'kubernetes/secondScanning',
           'flux/secondScanning',
@@ -64,7 +64,7 @@
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files - third IDE run"
-        measure="processingTime#Go"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="['kubernetes/thirdScanning', 'flux/thirdScanning', 'istio/thirdScanning', 'cockroach/thirdScanning', 'delve/thirdScanning', 'mattermost-server/thirdScanning']"
       />
     </section>

--- a/dashboard/new-dashboard/src/components/goland/InspectionCodeAnalyzesDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/InspectionCodeAnalyzesDashboard.vue
@@ -14,7 +14,7 @@
     </section>
     <section>
       <GroupProjectsChart
-        label="GloBbal inspection execution time: light projects"
+        label="Global inspection execution time: light projects"
         measure="globalInspections"
         :projects="['delve/inspection', 'flux/inspection', 'istio/inspection']"
       />

--- a/dashboard/new-dashboard/src/components/intelliJ/Jbr21PerformanceDashboard.vue
+++ b/dashboard/new-dashboard/src/components/intelliJ/Jbr21PerformanceDashboard.vue
@@ -2,7 +2,7 @@
   <DashboardPage
     db-name="perfint"
     table="idea"
-    persistent-id="jbr_21_idea_dashboard"
+    persistent-id="custom_jbr_idea_dashboard"
     initial-machine="Linux EC2 C6id.8xlarge (32 vCPU Xeon, 64 GB)"
     :charts="charts"
   >
@@ -28,177 +28,267 @@ const chartsDeclaration: ChartDefinition[] = [
   {
     labels: ["Indexing", "Scanning"],
     measures: ["indexingTimeWithoutPauses", "scanningTimeWithoutPauses"],
-    projects: ["21jbr-community/indexing", "community/indexing", "21jbr-intellij_sources/indexing", "intellij_sources/indexing"],
+    projects: [
+      "21jbr-community/indexing",
+      "community/indexing",
+      "21jbr-intellij_sources/indexing",
+      "intellij_sources/indexing",
+      "17jbr-community/indexing",
+      "17jbr-intellij_sources/indexing",
+    ],
   },
   {
     labels: ["VFS refresh"],
     measures: ["vfs_initial_refresh"],
-    projects: ["21jbr-intellij_sources/vfsRefresh/default", "intellij_sources/vfsRefresh/default"],
+    projects: ["21jbr-intellij_sources/vfsRefresh/default", "intellij_sources/vfsRefresh/default", "17jbr-intellij_sources/vfsRefresh/default"],
   },
   {
     labels: ["Compilation"],
     measures: ["build_compilation_duration"],
-    projects: ["21jbr-community/rebuild", "community/rebuild", "21jbr-intellij_sources/rebuild", "intellij_sources/rebuild"],
+    projects: [
+      "21jbr-community/rebuild",
+      "community/rebuild",
+      "21jbr-intellij_sources/rebuild",
+      "intellij_sources/rebuild",
+      "17jbr-community/rebuild",
+      "17jbr-intellij_sources/rebuild",
+    ],
   },
   {
     labels: ["Find Usages Library.getName() before compilation", "First Code Analysis"],
     measures: ["findUsages", "firstCodeAnalysis"],
-    projects: ["21jbr-community/findUsages/Library_getName_Before", "community/findUsages/Library_getName_Before"],
+    projects: ["21jbr-community/findUsages/Library_getName_Before", "community/findUsages/Library_getName_Before", "17jbr-community/findUsages/Library_getName_Before"],
   },
   {
     labels: ["Find Usages Library.getName() after compilation"],
     measures: ["findUsages"],
-    projects: ["21jbr-community/findUsages/Library_getName_After", "community/findUsages/Library_getName_After"],
+    projects: ["21jbr-community/findUsages/Library_getName_After", "community/findUsages/Library_getName_After", "17jbr-community/findUsages/Library_getName_After"],
   },
   {
     labels: ["Find Usages PsiManager.getInstance() before compilation", "First Code Analysis"],
     measures: ["findUsages", "firstCodeAnalysis"],
-    projects: ["21jbr-community/findUsages/PsiManager_getInstance_Before", "community/findUsages/PsiManager_getInstance_Before"],
+    projects: [
+      "21jbr-community/findUsages/PsiManager_getInstance_Before",
+      "community/findUsages/PsiManager_getInstance_Before",
+      "17jbr-community/findUsages/PsiManager_getInstance_Before",
+    ],
   },
   {
     labels: ["Find Usages PsiManager.getInstance() after compilation"],
     measures: ["findUsages"],
-    projects: ["21jbr-community/findUsages/PsiManager_getInstance_After", "community/findUsages/PsiManager_getInstance_After"],
+    projects: [
+      "21jbr-community/findUsages/PsiManager_getInstance_After",
+      "community/findUsages/PsiManager_getInstance_After",
+      "17jbr-community/findUsages/PsiManager_getInstance_After",
+    ],
   },
   {
     labels: ["SE: go-to-action Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-action/Editor/typingLetterByLetter", "community/go-to-action/Editor/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-action/Editor/typingLetterByLetter",
+      "community/go-to-action/Editor/typingLetterByLetter",
+      "17jbr-community/go-to-action/Editor/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-action Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-action/Kotlin/typingLetterByLetter", "community/go-to-action/Kotlin/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-action/Kotlin/typingLetterByLetter",
+      "community/go-to-action/Kotlin/typingLetterByLetter",
+      "17jbr-community/go-to-action/Kotlin/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-action Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-action/Runtime/typingLetterByLetter", "community/go-to-action/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-action/Runtime/typingLetterByLetter",
+      "community/go-to-action/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-action/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-all Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-all/Editor/typingLetterByLetter", "community/go-to-all/Editor/typingLetterByLetter"],
+    projects: ["21jbr-community/go-to-all/Editor/typingLetterByLetter", "community/go-to-all/Editor/typingLetterByLetter", "17jbr-community/go-to-all/Editor/typingLetterByLetter"],
   },
   {
     labels: ["SE: go-to-all Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-all/Kotlin/typingLetterByLetter", "community/go-to-all/Kotlin/typingLetterByLetter"],
+    projects: ["21jbr-community/go-to-all/Kotlin/typingLetterByLetter", "community/go-to-all/Kotlin/typingLetterByLetter", "17jbr-community/go-to-all/Kotlin/typingLetterByLetter"],
   },
   {
     labels: ["SE: go-to-all Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-all/Runtime/typingLetterByLetter", "community/go-to-all/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-all/Runtime/typingLetterByLetter",
+      "community/go-to-all/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-all/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-class Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-class/Editor/typingLetterByLetter", "community/go-to-class/Editor/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-class/Editor/typingLetterByLetter",
+      "community/go-to-class/Editor/typingLetterByLetter",
+      "17jbr-community/go-to-class/Editor/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-class Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-class/Kotlin/typingLetterByLetter", "community/go-to-class/Kotlin/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-class/Kotlin/typingLetterByLetter",
+      "community/go-to-class/Kotlin/typingLetterByLetter",
+      "17jbr-community/go-to-class/Kotlin/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-class Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-class/Runtime/typingLetterByLetter", "community/go-to-class/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-class/Runtime/typingLetterByLetter",
+      "community/go-to-class/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-class/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-file Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-file/Editor/typingLetterByLetter", "community/go-to-file/Editor/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-file/Editor/typingLetterByLetter",
+      "community/go-to-file/Editor/typingLetterByLetter",
+      "17jbr-community/go-to-file/Editor/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-file Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-file/Kotlin/typingLetterByLetter", "community/go-to-file/Kotlin/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-file/Kotlin/typingLetterByLetter",
+      "community/go-to-file/Kotlin/typingLetterByLetter",
+      "17jbr-community/go-to-file/Kotlin/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-file Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-file/Runtime/typingLetterByLetter", "community/go-to-file/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-file/Runtime/typingLetterByLetter",
+      "community/go-to-file/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-file/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-symbol Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-symbol/Editor/typingLetterByLetter", "community/go-to-symbol/Editor/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-symbol/Editor/typingLetterByLetter",
+      "community/go-to-symbol/Editor/typingLetterByLetter",
+      "17jbr-community/go-to-symbol/Editor/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-symbol Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-symbol/Kotlin/typingLetterByLetter", "community/go-to-symbol/Kotlin/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-symbol/Kotlin/typingLetterByLetter",
+      "community/go-to-symbol/Kotlin/typingLetterByLetter",
+      "17jbr-community/go-to-symbol/Kotlin/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-symbol Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-symbol/Runtime/typingLetterByLetter", "community/go-to-symbol/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-symbol/Runtime/typingLetterByLetter",
+      "community/go-to-symbol/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-symbol/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-text Editor"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-text/Editor/typingLetterByLetter", "community/go-to-text/Editor/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-text/Editor/typingLetterByLetter",
+      "community/go-to-text/Editor/typingLetterByLetter",
+      "17jbr-community/go-to-text/Editor/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-text Kotlin"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-text/Kotlin/typingLetterByLetter", "community/go-to-text/Kotlin/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-text/Kotlin/typingLetterByLetter",
+      "community/go-to-text/Kotlin/typingLetterByLetter",
+      "17jbr-community/go-to-text/Kotlin/typingLetterByLetter",
+    ],
   },
   {
     labels: ["SE: go-to-text Runtime"],
     measures: ["searchEverywhere"],
-    projects: ["21jbr-community/go-to-text/Runtime/typingLetterByLetter", "community/go-to-text/Runtime/typingLetterByLetter"],
+    projects: [
+      "21jbr-community/go-to-text/Runtime/typingLetterByLetter",
+      "community/go-to-text/Runtime/typingLetterByLetter",
+      "17jbr-community/go-to-text/Runtime/typingLetterByLetter",
+    ],
   },
   {
     labels: ["Local inspections java file"],
     measures: ["localInspections"],
-    projects: ["21jbr-intellij_sources/localInspection/java_file", "intellij_sources/localInspection/java_file"],
+    projects: ["21jbr-intellij_sources/localInspection/java_file", "intellij_sources/localInspection/java_file", "17jbr-intellij_sources/localInspection/java_file"],
   },
   {
     labels: ["Local inspections kotlin file"],
     measures: ["localInspections"],
-    projects: ["21jbr-intellij_sources/localInspection/kotlin_file", "intellij_sources/localInspection/kotlin_file"],
+    projects: ["21jbr-intellij_sources/localInspection/kotlin_file", "intellij_sources/localInspection/kotlin_file", "17jbr-intellij_sources/localInspection/kotlin_file"],
   },
   {
     labels: ["File History"],
     measures: ["showFileHistory"],
-    projects: ["21jbr-intellij_sources/showFileHistory/EditorImpl", "intellij_sources/showFileHistory/EditorImpl"],
+    projects: ["21jbr-intellij_sources/showFileHistory/EditorImpl", "intellij_sources/showFileHistory/EditorImpl", "17jbr-intellij_sources/showFileHistory/EditorImpl"],
   },
   {
     labels: ["File Structure dialogue java file"],
     measures: ["FileStructurePopup"],
-    projects: ["21jbr-intellij_sources/FileStructureDialog/java_file", "intellij_sources/FileStructureDialog/java_file"],
+    projects: ["21jbr-intellij_sources/FileStructureDialog/java_file", "intellij_sources/FileStructureDialog/java_file", "17jbr-intellij_sources/FileStructureDialog/java_file"],
   },
   {
     labels: ["File Structure dialogue kotlin file"],
     measures: ["FileStructurePopup"],
-    projects: ["21jbr-intellij_sources/FileStructureDialog/kotlin_file", "intellij_sources/FileStructureDialog/kotlin_file"],
+    projects: [
+      "21jbr-intellij_sources/FileStructureDialog/kotlin_file",
+      "intellij_sources/FileStructureDialog/kotlin_file",
+      "17jbr-intellij_sources/FileStructureDialog/kotlin_file",
+    ],
   },
   {
     labels: ["Expand Editor menu"],
     measures: ["%expandEditorMenu"],
-    projects: ["21jbr-intellij_sources/expandEditorMenu", "intellij_sources/expandEditorMenu"],
+    projects: ["21jbr-intellij_sources/expandEditorMenu", "intellij_sources/expandEditorMenu", "17jbr-intellij_sources/expandEditorMenu"],
   },
   {
     labels: ["Expand Main menu"],
     measures: ["%expandMainMenu"],
-    projects: ["21jbr-intellij_sources/expandMainMenu", "intellij_sources/expandMainMenu"],
+    projects: ["21jbr-intellij_sources/expandMainMenu", "intellij_sources/expandMainMenu", "17jbr-intellij_sources/expandMainMenu"],
   },
   {
     labels: ["Expand Project menu"],
     measures: ["%expandProjectMenu"],
-    projects: ["21jbr-intellij_sources/expandProjectMenu", "intellij_sources/expandProjectMenu"],
+    projects: ["21jbr-intellij_sources/expandProjectMenu", "intellij_sources/expandProjectMenu", "17jbr-intellij_sources/expandProjectMenu"],
   },
   {
     labels: ["Create new java class"],
     measures: ["createJavaFile"],
-    projects: ["21jbr-intellij_sources/createJavaClass", "intellij_sources/createJavaClass"],
+    projects: ["21jbr-intellij_sources/createJavaClass", "intellij_sources/createJavaClass", "17jbr-intellij_sources/createJavaClass"],
   },
   {
     labels: ["Create new kotlin class"],
     measures: ["createKotlinFile"],
-    projects: ["21jbr-intellij_sources/createKotlinClass", "intellij_sources/createKotlinClass"],
+    projects: ["21jbr-intellij_sources/createKotlinClass", "intellij_sources/createKotlinClass", "17jbr-intellij_sources/createKotlinClass"],
   },
 ]
 

--- a/dashboard/new-dashboard/src/components/intelliJ/PerformanceSEDashboard.vue
+++ b/dashboard/new-dashboard/src/components/intelliJ/PerformanceSEDashboard.vue
@@ -25,66 +25,28 @@ import DashboardPage from "../common/DashboardPage.vue"
 
 const chartsDeclaration: ChartDefinition[] = [
   {
-    labels: ["Search Everywhere (insert whole word)", "SE Dialog Shown (insert whole word)", "SE Items Loaded (insert whole word)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
-    projects: [
-      "community/go-to-action/SharedIndex",
-      "community/go-to-class/EditorImpl",
-      "community/go-to-class/SharedIndex",
-      "community/go-to-file/EditorImpl",
-      "community/go-to-file/SharedIndex",
-      "community/go-to-action/SharedIndex/insertingTheWholeWord",
-      "community/go-to-class/EditorImpl/insertingTheWholeWord",
-      "community/go-to-class/SharedIndex/insertingTheWholeWord",
-      "community/go-to-file/EditorImpl/insertingTheWholeWord",
-      "community/go-to-file/SharedIndex/insertingTheWholeWord",
-    ],
+    labels: ["Search Everywhere Class (slow typing)", "SE Dialog Shown Class (slow typing)"],
+    measures: ["searchEverywhere", "searchEverywhere_dialog_shown"],
+    projects: ["community/go-to-class/Kotlin/typingLetterByLetter", "community/go-to-class/Editor/typingLetterByLetter", "community/go-to-class/Runtime/typingLetterByLetter"],
   },
   {
-    labels: ["Search Everywhere Action (slow typing)", "SE Dialog Shown Action (slow typing)", "SE Items Loaded Action (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
-    projects: [
-      "community/go-to-action/Runtime",
-      "community/go-to-action/Runtime/typingLetterByLetter",
-      "community/go-to-action/Editor/typingLetterByLetter",
-      "community/go-to-action/Kotlin/typingLetterByLetter",
-      "community/go-to-action/Runtime/typingLetterByLetter",
-    ],
+    labels: ["Search Everywhere File (slow typing)", "SE Dialog Shown File (slow typing)"],
+    measures: ["searchEverywhere", "searchEverywhere_dialog_shown"],
+    projects: ["community/go-to-file/Editor/typingLetterByLetter", "community/go-to-file/Kotlin/typingLetterByLetter", "community/go-to-file/Runtime/typingLetterByLetter"],
   },
   {
-    labels: ["Search Everywhere Class (slow typing)", "SE Dialog Shown Class (slow typing)", "SE Items Loaded Class (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
-    projects: [
-      "community/go-to-class/Kotlin",
-      "community/go-to-class/Kotlin/typingLetterByLetter",
-      "community/go-to-class/Editor/typingLetterByLetter",
-      "community/go-to-class/Runtime/typingLetterByLetter",
-    ],
-  },
-  {
-    labels: ["Search Everywhere File (slow typing)", "SE Dialog Shown File (slow typing)", "SE Items Loaded File (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
-    projects: [
-      "community/go-to-file/properties",
-      "community/go-to-file/properties/typingLetterByLetter",
-      "community/go-to-file/Editor/typingLetterByLetter",
-      "community/go-to-file/Kotlin/typingLetterByLetter",
-      "community/go-to-file/Runtime/typingLetterByLetter",
-    ],
-  },
-  {
-    labels: ["Search Everywhere All (slow typing)", "SE Dialog Shown All (slow typing)", "SE Items Loaded All (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
+    labels: ["Search Everywhere All (slow typing)", "SE Dialog Shown All (slow typing)"],
+    measures: ["searchEverywhere", "searchEverywhere_dialog_shown"],
     projects: ["community/go-to-all/Editor/typingLetterByLetter", "community/go-to-all/Kotlin/typingLetterByLetter", "community/go-to-all/Runtime/typingLetterByLetter"],
   },
   {
-    labels: ["Search Everywhere Symbol (slow typing)", "SE Dialog Shown Symbol (slow typing)", "SE Items Loaded Symbol (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
+    labels: ["Search Everywhere Symbol (slow typing)", "SE Dialog Shown Symbol (slow typing)"],
+    measures: ["searchEverywhere", "searchEverywhere_dialog_shown"],
     projects: ["community/go-to-symbol/Editor/typingLetterByLetter", "community/go-to-symbol/Kotlin/typingLetterByLetter", "community/go-to-symbol/Runtime/typingLetterByLetter"],
   },
   {
-    labels: ["Search Everywhere Text (slow typing)", "SE Dialog Shown Text (slow typing)", "SE Items Loaded Text (slow typing)"],
-    measures: ["searchEverywhere", "searchEverywhere_dialog_shown", "searchEverywhere_items_loaded"],
+    labels: ["Search Everywhere Text (slow typing)", "SE Dialog Shown Text (slow typing)"],
+    measures: ["searchEverywhere", "searchEverywhere_dialog_shown"],
     projects: ["community/go-to-text/Editor/typingLetterByLetter", "community/go-to-text/Kotlin/typingLetterByLetter", "community/go-to-text/Runtime/typingLetterByLetter"],
   },
 ]

--- a/dashboard/new-dashboard/src/components/ml/dev/FullLineDashboard.vue
+++ b/dashboard/new-dashboard/src/components/ml/dev/FullLineDashboard.vue
@@ -12,6 +12,7 @@
         :measure="['inlineCompletionShow#mean_value']"
         :projects="[
           'kotlin_language_server/full-line-completion/DefinitionTest/empty-fun-full-line',
+          'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line',
           'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line flcc_fimModel=false flcc_ragEnabled=false',
           'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line flcc_fimModel=true flcc_ragEnabled=false',
           'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line flcc_fimModel=false flcc_ragEnabled=true',
@@ -23,6 +24,7 @@
         :measure="['inlineCompletionShow#mean_value']"
         :projects="[
           'kotlin_language_server/full-line-completion/DefinitionTest/empty-fun-full-line',
+          'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line',
           'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line flcc_maxModelCtx=1500',
           'kotlin_language_server_full_line/full-line-completion/DefinitionTest/empty-fun-full-line flcc_maxModelCtx=384',
         ]"

--- a/dashboard/new-dashboard/src/configurators/DimensionConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/DimensionConfigurator.ts
@@ -17,7 +17,7 @@ export class DimensionConfigurator implements DataQueryConfigurator, FilterConfi
   constructor(
     readonly name: string,
     readonly multiple: boolean,
-    public aliases: string[] | null = null
+    public aliases: Map<string, string> | null = null
   ) {
     this.observable = refToObservable(this.selected, true).pipe(shareReplay(1))
   }
@@ -76,7 +76,7 @@ export function dimensionConfigurator(
   multiple: boolean = false,
   filters: FilterConfigurator[] = [],
   customValueSort: ((a: string, b: string) => number) | null = null,
-  aliases: string[] | null = null
+  aliases: Map<string, string> | null = null
 ): DimensionConfigurator {
   const configurator = new DimensionConfigurator(name, multiple, aliases)
   persistentStateManager?.add(name, configurator.selected)
@@ -119,7 +119,7 @@ export function filterSelected(configurator: DimensionConfigurator, data: string
   }
 }
 
-export function configureQueryProducer(configuration: DataQueryExecutorConfiguration, filter: DataQueryFilter, values: string[], aliases: string[] | null = null): void {
+export function configureQueryProducer(configuration: DataQueryExecutorConfiguration, filter: DataQueryFilter, values: string[], aliases: Map<string, string> | null = null): void {
   configuration.queryProducers.push({
     size(): number {
       return values.length
@@ -128,8 +128,8 @@ export function configureQueryProducer(configuration: DataQueryExecutorConfigura
       filter.v = values[index]
     },
     getSeriesName(index: number): string {
-      if (aliases != null && aliases.length > index) {
-        return aliases[index]
+      if (aliases != null) {
+        return aliases.get(values[index]) ?? values[index]
       }
       return values[index]
     },

--- a/dashboard/new-dashboard/src/configurators/DimensionConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/DimensionConfigurator.ts
@@ -128,10 +128,7 @@ export function configureQueryProducer(configuration: DataQueryExecutorConfigura
       filter.v = values[index]
     },
     getSeriesName(index: number): string {
-      if (aliases != null) {
-        return aliases.get(values[index]) ?? values[index]
-      }
-      return values[index]
+      return aliases?.get(values[index]) ?? values[index]
     },
     getMeasureName(_index: number): string {
       return configuration.measures[0]


### PR DESCRIPTION
The metric used to measure the NumberOfIndexedFiles charts in the IndexingDashboard component has been updated. Previously, it was 'processingTime#Go' and now it's 'numberOfIndexedFilesWritingIndexValue', aligning the measure with the actual intent of depicting the number of indexed files.