### PR TITLE
Update measure metric in Indexed Files charts

### DIFF
--- a/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
+++ b/dashboard/new-dashboard/src/components/goland/IndexingDashboard.vue
@@ -50,7 +50,7 @@
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files - second IDE run"
-        measure="processingTime#Go"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="[
           'kubernetes/secondScanning',
           'flux/secondScanning',
@@ -64,7 +64,7 @@
     <section>
       <GroupProjectsChart
         label="Number Of Indexed Files - third IDE run"
-        measure="processingTime#Go"
+        measure="numberOfIndexedFilesWritingIndexValue"
         :projects="['kubernetes/thirdScanning', 'flux/thirdScanning', 'istio/thirdScanning', 'cockroach/thirdScanning', 'delve/thirdScanning', 'mattermost-server/thirdScanning']"
       />
     </section>


### PR DESCRIPTION
The metric used to measure the NumberOfIndexedFiles charts in the IndexingDashboard component has been updated. Previously, it was 'processingTime#Go' and now it's 'numberOfIndexedFilesWritingIndexValue', aligning the measure with the actual intent of depicting the number of indexed files.