### PR TITLE
Update jps.module.dependency.index.workspace.model.listener.on.change…

### DIFF
--- a/dashboard/new-dashboard/src/components/intelliJ/build-tools/jps/JpsImportPerformanceDashboard.vue
+++ b/dashboard/new-dashboard/src/components/intelliJ/build-tools/jps/JpsImportPerformanceDashboard.vue
@@ -67,6 +67,7 @@ const metricsDeclaration = [
   "jps.save.changed.project.entities.ms",
   "jps.save.global.entities.ms",
   "jps.storage.jps.conf.reader.load.component.ms",
+  "jps.module.dependency.index.workspace.model.listener.on.changed.ms",
 
   "workspaceModel.check.recursive.update.ms",
   "workspaceModel.collect.changes.ms",
@@ -151,8 +152,6 @@ const metricsDeclaration = [
   "workspaceModel.cachedValueWithParameters.total.get.count",
   "workspaceModel.cachedValue.clear.count",
   "workspaceModel.cachedValueWithParameters.clear.count",
-
-  "module.dependency.index.workspace.model.listener.on.changed.ms",
 
   "compiler.ArtifactBridge.beforeChanged.ms",
   "compiler.ArtifactManagerBridge.addArtifact.ms",


### PR DESCRIPTION
…d.ms metric

- Added a `jps.` prefix to meet the naming convention
- Moved closer to other metrics started with `jps.`