### PR TITLE
[Rust] add CrateDefMap size to startup dashboard

### DIFF
--- a/dashboard/new-dashboard/src/components/rust/PerformanceDashboardRustRoverFirstStartup.vue
+++ b/dashboard/new-dashboard/src/components/rust/PerformanceDashboardRustRoverFirstStartup.vue
@@ -91,6 +91,14 @@
         :projects="rustGlobalInspectionProjects.map((project) => `${project}/indexing`)"
       />
     </section>
+    <section>
+      <GroupProjectsChart
+        label="Rust CrateDefMaps size in MB (metric 'rust_class_instances_tree_size_mb#org.rust.lang.core.resolve2.CrateDefMap')"
+        measure="rust_class_instances_tree_size_mb#org.rust.lang.core.resolve2.CrateDefMap"
+        :projects="rustGlobalInspectionProjects.map((project) => `${project}/indexing`)"
+        value-unit="counter"
+      />
+    </section>
   </DashboardPage>
 </template>
 


### PR DESCRIPTION
We added a new metrict to our tests. And I would like to add it to the dashboard
cc @vlad20012 