### PR TITLE
Fix reporting of YouTrack issues by changing the default issue type to Performance Problem

### DIFF
--- a/pkg/server/meta/yourtrackClient.go
+++ b/pkg/server/meta/yourtrackClient.go
@@ -45,11 +45,12 @@ type Visibility struct {
 }
 
 type CreateIssueInfo struct {
-	Summary     string          `json:"summary"`
-	Description string          `json:"description"`
-	Project     YoutrackProject `json:"project"`
-	Reporter    *auth.YTUser    `json:"reporter,omitempty"`
-	Visibility  Visibility      `json:"visibility"`
+	Summary      string          `json:"summary"`
+	Description  string          `json:"description"`
+	Project      YoutrackProject `json:"project"`
+	Reporter     *auth.YTUser    `json:"reporter,omitempty"`
+	Visibility   Visibility      `json:"visibility"`
+	CustomFields []CustomField   `json:"customFields"`
 }
 
 func NewYoutrackClient(youTrackUrl, youtrackToken string) *YoutrackClient {

--- a/pkg/server/meta/youtrack.go
+++ b/pkg/server/meta/youtrack.go
@@ -142,6 +142,17 @@ func CreatePostCreateIssueByAccident(metaDb *pgxpool.Pool) http.HandlerFunc {
 				PermittedUsers:  []auth.YTUser{{ID: "11-1539792"}},
 				Type:            "LimitedVisibility",
 			},
+			CustomFields: []CustomField{
+				{
+					Name: "Type",
+					Type: "SingleEnumIssueCustomField",
+					Value: struct {
+						Name string `json:"name"`
+					}{
+						Name: "Performance Problem",
+					},
+				},
+			},
 		}
 
 		issue, err := youtrackClient.CreateIssue(request.Context(), issueInfo)


### PR DESCRIPTION
There's now a YouTrack workflow that blocks the creation of Bugs in IDEA and IJPL without an affected version.