### PR TITLE
[kotlin] Rename `HighlightMethodUtil` J2K test

### DIFF
--- a/dashboard/new-dashboard/resources/projects/kotlin_projects.json
+++ b/dashboard/new-dashboard/resources/projects/kotlin_projects.json
@@ -323,7 +323,7 @@
         "intellij_sources/javaToKotlin/HighlightFixUtil",
         "intellij_sources/javaToKotlin/CompilerConfigurationImpl",
         "intellij_sources/javaToKotlin/DaemonCodeAnalyzerImpl",
-        "intellij_sources/javaToKotlin/HighlightMethodUtil",
+        "intellij_sources/javaToKotlin/HighlightNamesUtil",
         "intellij_sources/javaToKotlin/EditorImpl"
       ]
     },


### PR DESCRIPTION
- `HighlightMethodUtil` was removed from the test project, and the corresponding performance test was changed to use `HighlightNamesUtil`.