### PR TITLE
introduce one endpoint to upload attachments to various targets

### DIFF
--- a/dashboard/new-dashboard/src/components/common/llmAnalysis/LlmAnalysisClient.ts
+++ b/dashboard/new-dashboard/src/components/common/llmAnalysis/LlmAnalysisClient.ts
@@ -8,6 +8,7 @@ export interface LlmAnalysisRequest {
   testMethodName: string | undefined
   youtrackIssueReadableId: string
   youtrackIssueId: string
+  spaceUploadedFiles: string[]
 }
 
 export class LlmAnalysisClient {

--- a/dashboard/new-dashboard/src/components/common/uploadAttachments/UploadAttachmentsClient.ts
+++ b/dashboard/new-dashboard/src/components/common/uploadAttachments/UploadAttachmentsClient.ts
@@ -1,0 +1,48 @@
+import { ServerConfigurator } from "../dataQuery"
+
+export enum UploadTarget {
+  YOUTRACK = "youtrack",
+  SPACE = "space",
+}
+
+export interface UploadAttachmentsRequest {
+  targets: UploadTarget[]
+  issueId: string
+  teamcityAttachmentInfo: {
+    currentBuildId: number
+    previousBuildId: number | undefined
+  }
+  chartPng: string | undefined
+  affectedTest: string
+  testType: string
+}
+
+export interface AttachmentsResponse {
+  uploads: Partial<Record<UploadTarget, string[]>>
+  exceptions: string[] | undefined
+}
+
+export class UploadAttachmentsClient {
+  private readonly serverConfigurator: ServerConfigurator | null
+
+  constructor(serverConfigurator: ServerConfigurator | null) {
+    this.serverConfigurator = serverConfigurator
+  }
+
+  async uploadAttachments(attachmentsInfo: UploadAttachmentsRequest) {
+    const url = `${this.serverConfigurator?.serverUrl}/api/meta/uploadAttachments`
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(attachmentsInfo),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to upload attachments. HTTP error: ${response.status}`)
+    }
+
+    return (await response.json()) as AttachmentsResponse
+  }
+}

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackClient.ts
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackClient.ts
@@ -32,23 +32,6 @@ export class YoutrackClient {
     }
   }
 
-  async uploadAttachments(attachmentsInfo: UploadAttachmentsRequest) {
-    const url = `${this.serverConfigurator?.serverUrl}/api/meta/uploadAttachments`
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(attachmentsInfo),
-    })
-
-    const attachmentsResponse = (await response.json()) as AttachmentsResponse
-
-    if (attachmentsResponse.exceptions != undefined || !response.ok) {
-      throw new Error(`Failed to upload attachments. Errors: ${attachmentsResponse.exceptions?.join("\n") ?? ""}`)
-    }
-  }
-
   private static readonly PROJECT_MAP: Record<string, Project[]> = {
     webstorm: [{ name: "WebStorm", id: "22-96" }],
     phpstorm: [{ name: "PhpStorm", id: "22-19" }],
@@ -94,30 +77,9 @@ export interface IssueResponse {
   issue: Issue
 }
 
-export interface AttachmentsResponse {
-  exceptions: string[] | undefined
-}
-
 interface Issue {
   id: string
   idReadable: string
-}
-
-export enum UploadTarget {
-  YOUTRACK = "youtrack",
-  SPACE = "space",
-}
-
-export interface UploadAttachmentsRequest {
-  targets: UploadTarget[]
-  issueId: string
-  teamcityAttachmentInfo: {
-    currentBuildId: number
-    previousBuildId: number | undefined
-  }
-  chartPng: string | undefined
-  affectedTest: string
-  testType: string
 }
 
 export interface CreateIssueRequest {

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackClient.ts
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackClient.ts
@@ -33,7 +33,7 @@ export class YoutrackClient {
   }
 
   async uploadAttachments(attachmentsInfo: UploadAttachmentsRequest) {
-    const url = `${this.serverConfigurator?.serverUrl}/api/meta/youtrack/uploadAttachments`
+    const url = `${this.serverConfigurator?.serverUrl}/api/meta/uploadAttachments`
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -103,7 +103,13 @@ interface Issue {
   idReadable: string
 }
 
+export enum UploadTarget {
+  YOUTRACK = "youtrack",
+  SPACE = "space",
+}
+
 export interface UploadAttachmentsRequest {
+  targets: UploadTarget[]
   issueId: string
   teamcityAttachmentInfo: {
     currentBuildId: number

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
@@ -146,7 +146,7 @@ import { Ref, ref } from "vue"
 import { useToast } from "primevue/usetoast"
 import { getNavigateToTestUrl, getSpaceUrl, InfoData } from "../sideBar/InfoSidebar"
 import { generateDefaultReason } from "../sideBar/AccidentUtils"
-import { CreateIssueRequest, IssueResponse, Project, UploadAttachmentsRequest, UploadTarget } from "./YoutrackClient"
+import { CreateIssueRequest, IssueResponse, Project } from "./YoutrackClient"
 import { Accident, AccidentKind, AccidentsConfigurator } from "../../../configurators/accidents/AccidentsConfigurator"
 import { serverConfiguratorKey, youtrackClientKey } from "../../../shared/keys"
 import { injectOrError } from "../../../shared/injectionKeys"
@@ -156,6 +156,7 @@ import { getPersistentLink } from "../../settings/CopyLink"
 import { TimeRangeConfigurator } from "../../../configurators/TimeRangeConfigurator"
 import { dbTypeStore } from "../../../shared/dbTypes"
 import { LlmAnalysisClient, LlmAnalysisRequest } from "../llmAnalysis/LlmAnalysisClient"
+import { AttachmentsResponse, UploadAttachmentsClient, UploadAttachmentsRequest, UploadTarget } from "../uploadAttachments/UploadAttachmentsClient"
 
 enum DownloadState {
   NOT_STARTED,
@@ -174,6 +175,7 @@ const { data, accident, accidentConfigurator, timerangeConfigurator } = definePr
 
 const youtrackClient = injectOrError(youtrackClientKey)
 const serverConfigurator = injectOrError(serverConfiguratorKey)
+const uploadAttachmentsClient = new UploadAttachmentsClient(serverConfigurator)
 const llmAnalysisClient = new LlmAnalysisClient(serverConfigurator)
 const toast = useToast()
 const showYoutrackDialog = defineModel<boolean>()
@@ -228,6 +230,7 @@ async function createTicket() {
     }
 
     let issueResponse: IssueResponse
+    let attachmentsResponse: AttachmentsResponse | undefined
     try {
       issueResponse = await youtrackClient.createIssue(issueInfo)
       createdTicket.value = issueResponse.issue.idReadable
@@ -309,7 +312,15 @@ async function createTicket() {
             })
           })
       }
-      await youtrackClient.uploadAttachments(attachmentsInfo)
+      attachmentsResponse = await uploadAttachmentsClient.uploadAttachments(attachmentsInfo)
+      if (attachmentsResponse.exceptions != undefined) {
+        toast.add({
+          severity: "error",
+          summary: "Attachment Upload Failed",
+          detail: `Failed to upload attachments. Errors: ${attachmentsResponse.exceptions?.join("\n") ?? ""}`,
+          life: 8000,
+        })
+      }
     } catch (error: unknown) {
       console.error(error)
       const errorMessage = error instanceof Error ? error.message : String(error)
@@ -332,6 +343,7 @@ async function createTicket() {
           testMethodName: data.description.value?.methodName?.replaceAll("#", "."),
           youtrackIssueReadableId: issueResponse.issue.idReadable,
           youtrackIssueId: issueResponse.issue.id,
+          spaceUploadedFiles: attachmentsResponse?.uploads[UploadTarget.SPACE] ?? [],
         }
         llmAnalysisBuildUrl.value = await llmAnalysisClient.sendLlmAnalysisRequest(llmAnalysisRequest)
       } catch (error: unknown) {

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
@@ -313,7 +313,7 @@ async function createTicket() {
           })
       }
       attachmentsResponse = await uploadAttachmentsClient.uploadAttachments(attachmentsInfo)
-      if (attachmentsResponse.exceptions != undefined) {
+      if (attachmentsResponse.exceptions?.length) {
         toast.add({
           severity: "error",
           summary: "Attachment Upload Failed",

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
@@ -146,7 +146,7 @@ import { Ref, ref } from "vue"
 import { useToast } from "primevue/usetoast"
 import { getNavigateToTestUrl, getSpaceUrl, InfoData } from "../sideBar/InfoSidebar"
 import { generateDefaultReason } from "../sideBar/AccidentUtils"
-import { CreateIssueRequest, IssueResponse, Project, UploadAttachmentsRequest } from "./YoutrackClient"
+import { CreateIssueRequest, IssueResponse, Project, UploadAttachmentsRequest, UploadTarget } from "./YoutrackClient"
 import { Accident, AccidentKind, AccidentsConfigurator } from "../../../configurators/accidents/AccidentsConfigurator"
 import { serverConfiguratorKey, youtrackClientKey } from "../../../shared/keys"
 import { injectOrError } from "../../../shared/injectionKeys"
@@ -275,6 +275,7 @@ async function createTicket() {
         affectedTest = affectedTest.slice(0, -affectedMetric.length - 1)
       }
       const attachmentsInfo: UploadAttachmentsRequest = {
+        targets: [UploadTarget.YOUTRACK, UploadTarget.SPACE],
         issueId: issueResponse.issue.id,
         teamcityAttachmentInfo: {
           currentBuildId: buildId,

--- a/pkg/server/meta/artifactsUpload.go
+++ b/pkg/server/meta/artifactsUpload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -109,17 +110,12 @@ func (u *spaceUploader) Type() UploadTarget {
 	return Space
 }
 
-func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte, fileName string, errCh chan<- error, uploadWg *sync.WaitGroup, results *uploadResults) {
+func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte, fileName string, handleUploadErrors func(string, error, UploadTarget), uploadWg *sync.WaitGroup, results *uploadResults) {
 	for _, uploader := range uploaders {
 		uploadWg.Go(func() {
 			err := uploader.Upload(ctx, file, fileName)
 			if err != nil {
-				if uploader.Type() == YouTrack {
-					slog.Error("Failed to upload attachment to youtrack", "error", err)
-					errCh <- err
-				} else {
-					slog.Error("Failed to upload attachment", "target", uploader.Type(), "error", err)
-				}
+				handleUploadErrors("Failed to upload attachment", err, uploader.Type())
 			} else {
 				results.addSuccess(uploader.Type(), fileName)
 			}
@@ -154,7 +150,22 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 			return
 		}
 
-		errCh := make(chan error, 10)
+		var exceptionsMu sync.Mutex
+		logAndAddException := func(message string, err error) {
+			slog.Error(message, "error", err)
+			exceptionsMu.Lock()
+			defer exceptionsMu.Unlock()
+			response.Exceptions = append(response.Exceptions,
+				fmt.Sprintf("Message: %s. Error: %s", message, err.Error()))
+		}
+		handleUploadError := func(message string, err error, target UploadTarget) {
+			if target == YouTrack {
+				logAndAddException(message, err)
+			} else {
+				slog.Error(message, "target", target, "error", err)
+			}
+		}
+
 		var uploadWg sync.WaitGroup
 		results := newUploadResults()
 
@@ -164,7 +175,7 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 		}
 
 		if params.ChartPng != nil {
-			uploadToAll(request.Context(), uploaders, *params.ChartPng, "dashboard.png", errCh, &uploadWg, results)
+			uploadToAll(request.Context(), uploaders, *params.ChartPng, "dashboard.png", handleUploadError, &uploadWg, results)
 		}
 
 		collector := getArtifactCollector(params.TestType)
@@ -177,8 +188,7 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 
 					children, err := teamCityClient.getArtifactChildren(request.Context(), buildId, testArtifactPath)
 					if err != nil {
-						slog.Error("Failed to get teamcity artifact children", "error", err)
-						errCh <- err
+						logAndAddException("Failed to get teamcity artifact children", err)
 						return
 					}
 
@@ -202,13 +212,12 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 						childWg.Go(func() {
 							artifact, err := teamCityClient.downloadArtifact(request.Context(), buildId, testArtifactPath+"/"+str)
 							if err != nil {
-								slog.Error("Failed to download artefacts form teamcity", "error", err)
-								errCh <- err
+								logAndAddException("Failed to download artifacts from teamcity", err)
 								return
 							}
 
 							attachmentName := getAttachmentName(str, attachmentPostfix)
-							uploadToAll(request.Context(), uploaders, artifact, attachmentName, errCh, &uploadWg, results)
+							uploadToAll(request.Context(), uploaders, artifact, attachmentName, handleUploadError, &uploadWg, results)
 						})
 					}
 					childWg.Wait()
@@ -218,13 +227,6 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 		}
 
 		uploadWg.Wait()
-		close(errCh)
-
-		for err := range errCh {
-			if err != nil {
-				response.Exceptions = append(response.Exceptions, err.Error())
-			}
-		}
 
 		response.Uploads = results.uploads
 

--- a/pkg/server/meta/artifactsUpload.go
+++ b/pkg/server/meta/artifactsUpload.go
@@ -26,6 +26,28 @@ const (
 	Space    UploadTarget = "space"
 )
 
+type UploadAttachmentsResponse struct {
+	Uploads    map[string][]string `json:"uploads"`
+	Exceptions []string            `json:"exceptions"`
+}
+
+type uploadResults struct {
+	mu      sync.Mutex
+	uploads map[string][]string
+}
+
+func newUploadResults() *uploadResults {
+	return &uploadResults{
+		uploads: make(map[string][]string),
+	}
+}
+
+func (ur *uploadResults) addSuccess(target UploadTarget, fileName string) {
+	ur.mu.Lock()
+	defer ur.mu.Unlock()
+	ur.uploads[string(target)] = append(ur.uploads[string(target)], fileName)
+}
+
 func (request *UploadAttachmentsRequest) ToUploaders() ([]ArtifactsUploader, error) {
 	uploaders := make([]ArtifactsUploader, 0, len(request.Targets))
 
@@ -87,7 +109,7 @@ func (u *spaceUploader) Type() UploadTarget {
 	return Space
 }
 
-func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte, fileName string, errCh chan<- error, uploadWg *sync.WaitGroup) {
+func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte, fileName string, errCh chan<- error, uploadWg *sync.WaitGroup, results *uploadResults) {
 	for _, uploader := range uploaders {
 		uploadWg.Go(func() {
 			err := uploader.Upload(ctx, file, fileName)
@@ -98,6 +120,8 @@ func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte
 				} else {
 					slog.Error("Failed to upload attachment", "target", uploader.Type(), "error", err)
 				}
+			} else {
+				results.addSuccess(uploader.Type(), fileName)
 			}
 		})
 	}
@@ -105,16 +129,12 @@ func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte
 
 func CreatePostUploadAttachments() http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		type Exceptions struct {
-			Exceptions []string `json:"exceptions"`
-		}
-
-		var exceptions Exceptions
+		var response UploadAttachmentsResponse
 		body := request.Body
 		all, err := io.ReadAll(body)
 		if err != nil {
-			handleError(writer, "cannot read body", err, &exceptions.Exceptions)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			handleError(writer, "cannot read body", err, &response.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, response)
 			return
 		}
 
@@ -122,20 +142,21 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 
 		var params UploadAttachmentsRequest
 		if err = json.Unmarshal(all, &params); err != nil {
-			handleError(writer, "cannot unmarshal parameters", err, &exceptions.Exceptions)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			handleError(writer, "cannot unmarshal parameters", err, &response.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, response)
 			return
 		}
 
 		uploaders, err := params.ToUploaders()
 		if err != nil {
-			handleError(writer, "invalid upload targets", err, &exceptions.Exceptions)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			handleError(writer, "invalid upload targets", err, &response.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, response)
 			return
 		}
 
 		errCh := make(chan error, 10)
 		var uploadWg sync.WaitGroup
+		results := newUploadResults()
 
 		builds := []int{params.TeamCityAttachmentInfo.CurrentBuildId}
 		if params.TeamCityAttachmentInfo.PreviousBuildId != nil {
@@ -143,7 +164,7 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 		}
 
 		if params.ChartPng != nil {
-			uploadToAll(request.Context(), uploaders, *params.ChartPng, "dashboard.png", errCh, &uploadWg)
+			uploadToAll(request.Context(), uploaders, *params.ChartPng, "dashboard.png", errCh, &uploadWg, results)
 		}
 
 		collector := getArtifactCollector(params.TestType)
@@ -187,7 +208,7 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 							}
 
 							attachmentName := getAttachmentName(str, attachmentPostfix)
-							uploadToAll(request.Context(), uploaders, artifact, attachmentName, errCh, &uploadWg)
+							uploadToAll(request.Context(), uploaders, artifact, attachmentName, errCh, &uploadWg, results)
 						})
 					}
 					childWg.Wait()
@@ -201,16 +222,18 @@ func CreatePostUploadAttachments() http.HandlerFunc {
 
 		for err := range errCh {
 			if err != nil {
-				exceptions.Exceptions = append(exceptions.Exceptions, err.Error())
+				response.Exceptions = append(response.Exceptions, err.Error())
 			}
 		}
 
-		if len(exceptions.Exceptions) > 0 {
+		response.Uploads = results.uploads
+
+		if len(response.Exceptions) > 0 {
 			writer.WriteHeader(http.StatusInternalServerError)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			_ = marshalAndWriteIssueResponse(writer, response)
 			return
 		}
 
-		_ = marshalAndWriteIssueResponse(writer, exceptions)
+		_ = marshalAndWriteIssueResponse(writer, response)
 	}
 }

--- a/pkg/server/meta/artifactsUpload.go
+++ b/pkg/server/meta/artifactsUpload.go
@@ -1,0 +1,216 @@
+package meta
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+)
+
+type UploadAttachmentsRequest struct {
+	Targets                []UploadTarget         `json:"targets"`
+	IssueId                string                 `json:"issueId"`
+	TeamCityAttachmentInfo TeamCityAttachmentInfo `json:"teamcityAttachmentInfo"`
+	AffectedTest           string                 `json:"affectedTest"`
+	ChartPng               *[]byte                `json:"chartPng"`
+	TestType               string                 `json:"testType"`
+}
+
+type UploadTarget string
+
+const (
+	YouTrack UploadTarget = "youtrack"
+	Space    UploadTarget = "space"
+)
+
+func (request *UploadAttachmentsRequest) ToUploaders() ([]ArtifactsUploader, error) {
+	uploaders := make([]ArtifactsUploader, 0, len(request.Targets))
+
+	for _, target := range request.Targets {
+		switch target {
+		case YouTrack:
+			uploaders = append(uploaders, &youtrackUploader{
+				client:  youtrackClient,
+				issueId: request.IssueId,
+			})
+		case Space:
+			uploaders = append(uploaders, &spaceUploader{
+				client:  spacePackagesClient,
+				issueId: request.IssueId,
+			})
+		default:
+			slog.Warn("Unknown upload target, skipping", "target", target)
+		}
+	}
+
+	if len(uploaders) == 0 {
+		if len(request.Targets) == 0 {
+			return nil, errors.New("no upload targets specified")
+		}
+		return nil, errors.New("no valid upload targets found")
+	}
+
+	return uploaders, nil
+}
+
+type ArtifactsUploader interface {
+	Upload(ctx context.Context, file []byte, fileName string) error
+	Type() UploadTarget
+}
+
+type youtrackUploader struct {
+	client  *YoutrackClient
+	issueId string
+}
+
+func (u *youtrackUploader) Upload(ctx context.Context, file []byte, fileName string) error {
+	return u.client.UploadAttachment(ctx, u.issueId, file, fileName)
+}
+
+func (u *youtrackUploader) Type() UploadTarget {
+	return YouTrack
+}
+
+type spaceUploader struct {
+	client  *SpacePackagesClient
+	issueId string
+}
+
+func (u *spaceUploader) Upload(ctx context.Context, file []byte, fileName string) error {
+	return u.client.UploadFile(ctx, "platform-test-automation", "performance-regression-llm-analysis", "analyses/"+u.issueId, fileName, file)
+}
+
+func (u *spaceUploader) Type() UploadTarget {
+	return Space
+}
+
+func uploadToAll(ctx context.Context, uploaders []ArtifactsUploader, file []byte, fileName string, errCh chan<- error, uploadWg *sync.WaitGroup) {
+	for _, uploader := range uploaders {
+		uploadWg.Go(func() {
+			err := uploader.Upload(ctx, file, fileName)
+			if err != nil {
+				if uploader.Type() == YouTrack {
+					slog.Error("Failed to upload attachment to youtrack", "error", err)
+					errCh <- err
+				} else {
+					slog.Error("Failed to upload attachment", "target", uploader.Type(), "error", err)
+				}
+			}
+		})
+	}
+}
+
+func CreatePostUploadAttachments() http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		type Exceptions struct {
+			Exceptions []string `json:"exceptions"`
+		}
+
+		var exceptions Exceptions
+		body := request.Body
+		all, err := io.ReadAll(body)
+		if err != nil {
+			handleError(writer, "cannot read body", err, &exceptions.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			return
+		}
+
+		defer body.Close()
+
+		var params UploadAttachmentsRequest
+		if err = json.Unmarshal(all, &params); err != nil {
+			handleError(writer, "cannot unmarshal parameters", err, &exceptions.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			return
+		}
+
+		uploaders, err := params.ToUploaders()
+		if err != nil {
+			handleError(writer, "invalid upload targets", err, &exceptions.Exceptions)
+			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			return
+		}
+
+		errCh := make(chan error, 10)
+		var uploadWg sync.WaitGroup
+
+		builds := []int{params.TeamCityAttachmentInfo.CurrentBuildId}
+		if params.TeamCityAttachmentInfo.PreviousBuildId != nil {
+			builds = append(builds, *params.TeamCityAttachmentInfo.PreviousBuildId)
+		}
+
+		if params.ChartPng != nil {
+			uploadToAll(request.Context(), uploaders, *params.ChartPng, "dashboard.png", errCh, &uploadWg)
+		}
+
+		collector := getArtifactCollector(params.TestType)
+
+		if collector != nil {
+			var wg sync.WaitGroup
+			for index, buildId := range builds {
+				wg.Go(func() {
+					testArtifactPath := collector.getArtifactsPath(params)
+
+					children, err := teamCityClient.getArtifactChildren(request.Context(), buildId, testArtifactPath)
+					if err != nil {
+						slog.Error("Failed to get teamcity artifact children", "error", err)
+						errCh <- err
+						return
+					}
+
+					var filteredChildren []string
+
+					for _, str := range children {
+						if collector.checkArtifact(str) {
+							filteredChildren = append(filteredChildren, str)
+						}
+					}
+
+					var attachmentPostfix string
+					if index == 0 {
+						attachmentPostfix = "current"
+					} else {
+						attachmentPostfix = "before"
+					}
+
+					var childWg sync.WaitGroup
+					for _, str := range filteredChildren {
+						childWg.Go(func() {
+							artifact, err := teamCityClient.downloadArtifact(request.Context(), buildId, testArtifactPath+"/"+str)
+							if err != nil {
+								slog.Error("Failed to download artefacts form teamcity", "error", err)
+								errCh <- err
+								return
+							}
+
+							attachmentName := getAttachmentName(str, attachmentPostfix)
+							uploadToAll(request.Context(), uploaders, artifact, attachmentName, errCh, &uploadWg)
+						})
+					}
+					childWg.Wait()
+				})
+			}
+			wg.Wait()
+		}
+
+		uploadWg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			if err != nil {
+				exceptions.Exceptions = append(exceptions.Exceptions, err.Error())
+			}
+		}
+
+		if len(exceptions.Exceptions) > 0 {
+			writer.WriteHeader(http.StatusInternalServerError)
+			_ = marshalAndWriteIssueResponse(writer, exceptions)
+			return
+		}
+
+		_ = marshalAndWriteIssueResponse(writer, exceptions)
+	}
+}

--- a/pkg/server/meta/artifactsUpload.go
+++ b/pkg/server/meta/artifactsUpload.go
@@ -28,25 +28,25 @@ const (
 )
 
 type UploadAttachmentsResponse struct {
-	Uploads    map[string][]string `json:"uploads"`
-	Exceptions []string            `json:"exceptions"`
+	Uploads    map[UploadTarget][]string `json:"uploads"`
+	Exceptions []string                  `json:"exceptions"`
 }
 
 type uploadResults struct {
 	mu      sync.Mutex
-	uploads map[string][]string
+	uploads map[UploadTarget][]string
 }
 
 func newUploadResults() *uploadResults {
 	return &uploadResults{
-		uploads: make(map[string][]string),
+		uploads: make(map[UploadTarget][]string),
 	}
 }
 
 func (ur *uploadResults) addSuccess(target UploadTarget, fileName string) {
 	ur.mu.Lock()
 	defer ur.mu.Unlock()
-	ur.uploads[string(target)] = append(ur.uploads[string(target)], fileName)
+	ur.uploads[target] = append(ur.uploads[target], fileName)
 }
 
 func (request *UploadAttachmentsRequest) ToUploaders() ([]ArtifactsUploader, error) {

--- a/pkg/server/meta/llmAnalysis.go
+++ b/pkg/server/meta/llmAnalysis.go
@@ -7,19 +7,21 @@ import (
 )
 
 type LLMAnalysisRequest struct {
-	CurrentBuildId          string  `json:"currentBuildId"`
-	AffectedMetric          string  `json:"affectedMetric"`
-	CurrentValue            *string `json:"currentValue"`
-	PreviousValue           *string `json:"previousValue"`
-	TestMethodName          *string `json:"testMethodName"`
-	YoutrackIssueReadableId string  `json:"youtrackIssueReadableId"`
-	YoutrackIssueId         string  `json:"youtrackIssueId"`
+	CurrentBuildId          string   `json:"currentBuildId"`
+	AffectedMetric          string   `json:"affectedMetric"`
+	CurrentValue            *string  `json:"currentValue"`
+	PreviousValue           *string  `json:"previousValue"`
+	TestMethodName          *string  `json:"testMethodName"`
+	YoutrackIssueReadableId string   `json:"youtrackIssueReadableId"`
+	YoutrackIssueId         string   `json:"youtrackIssueId"`
+	SpaceUploadedFiles      []string `json:"spaceUploadedFiles"`
 }
 
 type DegradationData struct {
-	CommitRange *CommitRange `json:"commitRange,omitempty"`
-	TestName    *string      `json:"testName,omitempty"`
-	Metric      *Metric      `json:"metric,omitempty"`
+	CommitRange   *CommitRange `json:"commitRange,omitempty"`
+	TestName      *string      `json:"testName,omitempty"`
+	Metric        *Metric      `json:"metric,omitempty"`
+	UploadedFiles []string     `json:"uploadedFiles"`
 }
 
 type CommitRange struct {
@@ -57,6 +59,7 @@ func CreatePostStartLlmAnalysis() http.HandlerFunc {
 				ValueBefore: llmAnalysisRequest.PreviousValue,
 				ValueAfter:  llmAnalysisRequest.CurrentValue,
 			},
+			UploadedFiles: llmAnalysisRequest.SpaceUploadedFiles,
 		}
 
 		if commits != nil {

--- a/pkg/server/meta/llmAnalysis.go
+++ b/pkg/server/meta/llmAnalysis.go
@@ -72,6 +72,18 @@ func CreatePostStartLlmAnalysis() http.HandlerFunc {
 			return
 		}
 
+		err = spacePackagesClient.UploadFile(
+			request.Context(),
+			"platform-test-automation",
+			"performance-regression-llm-analysis",
+			"analyses/"+llmAnalysisRequest.YoutrackIssueId,
+			"degradation-data.json",
+			degradationDataJSON,
+		)
+		if err != nil {
+			slog.Error("failed to upload degradation data to space", "error", err)
+		}
+
 		buildParams := map[string]string{
 			"degradation.data":           string(degradationDataJSON),
 			"youtrack.issue.readable.id": llmAnalysisRequest.YoutrackIssueReadableId,

--- a/pkg/server/meta/spaceClient.go
+++ b/pkg/server/meta/spaceClient.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 )
+
+var spacePackagesClient = NewSpacePackagesClient("https://packages.jetbrains.team", os.Getenv("SPACE_TOKEN"))
 
 type SpacePackagesClient struct {
 	spaceUrl   string

--- a/pkg/server/meta/youtrack.go
+++ b/pkg/server/meta/youtrack.go
@@ -1,10 +1,7 @@
 package meta
 
 import (
-	"archive/zip"
-	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,8 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/JetBrains/ij-perf-report-aggregator/pkg/server/auth"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -88,10 +83,9 @@ const (
 )
 
 var (
-	teamCityClient      = NewTeamCityClient("https://buildserver.labs.intellij.net", os.Getenv("TEAMCITY_TOKEN"))
-	youtrackClient      = NewYoutrackClient("https://youtrack.jetbrains.com", os.Getenv("YOUTRACK_TOKEN"))
-	ytAuth              = auth.NewYTAuth("https://youtrack.jetbrains.com", os.Getenv("YOUTRACK_TOKEN"))
-	spacePackagesClient = NewSpacePackagesClient("https://packages.jetbrains.team", os.Getenv("SPACE_TOKEN"))
+	teamCityClient = NewTeamCityClient("https://buildserver.labs.intellij.net", os.Getenv("TEAMCITY_TOKEN"))
+	youtrackClient = NewYoutrackClient("https://youtrack.jetbrains.com", os.Getenv("YOUTRACK_TOKEN"))
+	ytAuth         = auth.NewYTAuth("https://youtrack.jetbrains.com", os.Getenv("YOUTRACK_TOKEN"))
 )
 
 func CreatePostCreateIssueByAccident(metaDb *pgxpool.Pool) http.HandlerFunc {
@@ -251,13 +245,13 @@ func CreatePostCreateIssueByAccident(metaDb *pgxpool.Pool) http.HandlerFunc {
 }
 
 type artifactCollector interface {
-	getArtifactsPath(params UploadAttachmentsToIssueRequest) string
+	getArtifactsPath(params UploadAttachmentsRequest) string
 	checkArtifact(artifactName string) bool
 }
 
 type fleetStartupCollector struct{}
 
-func (f fleetStartupCollector) getArtifactsPath(UploadAttachmentsToIssueRequest) string {
+func (f fleetStartupCollector) getArtifactsPath(UploadAttachmentsRequest) string {
 	return ""
 }
 
@@ -267,7 +261,7 @@ func (f fleetStartupCollector) checkArtifact(artifactName string) bool {
 
 type fleetPerfTestCollector struct{}
 
-func (f fleetPerfTestCollector) getArtifactsPath(UploadAttachmentsToIssueRequest) string {
+func (f fleetPerfTestCollector) getArtifactsPath(UploadAttachmentsRequest) string {
 	return ""
 }
 
@@ -277,7 +271,7 @@ func (f fleetPerfTestCollector) checkArtifact(artifactName string) bool {
 
 type perfUnitTestCollector struct{}
 
-func (f perfUnitTestCollector) getArtifactsPath(params UploadAttachmentsToIssueRequest) string {
+func (f perfUnitTestCollector) getArtifactsPath(params UploadAttachmentsRequest) string {
 	return params.AffectedTest
 }
 
@@ -287,7 +281,7 @@ func (f perfUnitTestCollector) checkArtifact(artifactName string) bool {
 
 type perfintCollector struct{}
 
-func (f perfintCollector) getArtifactsPath(params UploadAttachmentsToIssueRequest) string {
+func (f perfintCollector) getArtifactsPath(params UploadAttachmentsRequest) string {
 	return strings.ReplaceAll(params.AffectedTest, "_", "-")
 }
 
@@ -316,176 +310,6 @@ func getArtifactCollector(testType string) artifactCollector {
 		return perfUnitTestCollector{}
 	default:
 		return nil
-	}
-}
-
-func createZipArchive(files *sync.Map) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	zipWriter := zip.NewWriter(buf)
-
-	var zipErr error
-	files.Range(func(key, value any) bool {
-		name, ok := key.(string)
-		if !ok {
-			zipErr = errors.New("invalid key type: expected string")
-			return false
-		}
-		data, ok := value.([]byte)
-		if !ok {
-			zipErr = errors.New("invalid value type: expected []byte")
-			return false
-		}
-
-		header := &zip.FileHeader{
-			Name:     name,
-			Method:   zip.Deflate,
-			Modified: time.Now(),
-		}
-		writer, err := zipWriter.CreateHeader(header)
-		if err != nil {
-			zipErr = err
-			return false
-		}
-		if _, err := writer.Write(data); err != nil {
-			zipErr = err
-			return false
-		}
-		return true
-	})
-
-	if zipErr != nil {
-		return nil, zipErr
-	}
-	if err := zipWriter.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func CreatePostUploadAttachmentsToIssue() http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		type Exceptions struct {
-			Exceptions []string `json:"exceptions"`
-		}
-
-		var exceptions Exceptions
-		body := request.Body
-		all, err := io.ReadAll(body)
-		if err != nil {
-			handleError(writer, "cannot read body", err, &exceptions.Exceptions)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
-			return
-		}
-
-		defer body.Close()
-
-		var params UploadAttachmentsToIssueRequest
-		if err = json.Unmarshal(all, &params); err != nil {
-			handleError(writer, "cannot unmarshal parameters", err, &exceptions.Exceptions)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
-			return
-		}
-
-		errCh := make(chan error, 10)
-		// for upload to space
-		filesToZip := &sync.Map{}
-
-		builds := []int{params.TeamCityAttachmentInfo.CurrentBuildId}
-		if params.TeamCityAttachmentInfo.PreviousBuildId != nil {
-			builds = append(builds, *params.TeamCityAttachmentInfo.PreviousBuildId)
-		}
-
-		if params.ChartPng != nil {
-			err := youtrackClient.UploadAttachment(request.Context(), params.IssueId, *params.ChartPng, "dashboard.png")
-			if err != nil {
-				slog.Error("Failed to upload dashboard attachment to youtrack", "error", err)
-				errCh <- err
-			}
-			filesToZip.Store("dashboard.png", *params.ChartPng)
-		}
-
-		collector := getArtifactCollector(params.TestType)
-
-		if collector != nil {
-			var wg sync.WaitGroup
-			for index, buildId := range builds {
-				wg.Go(func() {
-					testArtifactPath := collector.getArtifactsPath(params)
-
-					children, err := teamCityClient.getArtifactChildren(request.Context(), buildId, testArtifactPath)
-					if err != nil {
-						slog.Error("Failed to get teamcity artifact children", "error", err)
-						errCh <- err
-						return
-					}
-
-					var filteredChildren []string
-
-					for _, str := range children {
-						if collector.checkArtifact(str) {
-							filteredChildren = append(filteredChildren, str)
-						}
-					}
-
-					var attachmentPostfix string
-					if index == 0 {
-						attachmentPostfix = "current"
-					} else {
-						attachmentPostfix = "before"
-					}
-
-					var childWg sync.WaitGroup
-					for _, str := range filteredChildren {
-						childWg.Go(func() {
-							artifact, err := teamCityClient.downloadArtifact(request.Context(), buildId, testArtifactPath+"/"+str)
-							if err != nil {
-								slog.Error("Failed to download artefacts form teamcity", "error", err)
-								errCh <- err
-								return
-							}
-
-							attachmentName := getAttachmentName(str, attachmentPostfix)
-							err = youtrackClient.UploadAttachment(request.Context(), params.IssueId, artifact, attachmentName)
-							if err != nil {
-								slog.Error("Failed to upload attachment to youtrack", "error", err)
-								errCh <- err
-								return
-							}
-							filesToZip.Store(attachmentName, artifact)
-						})
-					}
-					childWg.Wait()
-				})
-			}
-			wg.Wait()
-		}
-
-		// Create ZIP archive and upload to Space Packages
-		zipData, err := createZipArchive(filesToZip)
-		if err != nil {
-			slog.Error("Failed to create zip archive", "error", err)
-		} else {
-			err = spacePackagesClient.UploadFile(request.Context(), "platform-test-automation", "performance-regression-llm-analysis", "analyses", params.IssueId+".zip", zipData)
-			if err != nil {
-				slog.Error("Failed to upload zip archive to space", "error", err)
-			}
-		}
-
-		close(errCh)
-
-		for err := range errCh {
-			if err != nil {
-				exceptions.Exceptions = append(exceptions.Exceptions, err.Error())
-			}
-		}
-
-		if len(exceptions.Exceptions) > 0 {
-			writer.WriteHeader(http.StatusInternalServerError)
-			_ = marshalAndWriteIssueResponse(writer, exceptions)
-			return
-		}
-
-		_ = marshalAndWriteIssueResponse(writer, exceptions)
 	}
 }
 

--- a/pkg/server/meta/youtrack.go
+++ b/pkg/server/meta/youtrack.go
@@ -418,7 +418,12 @@ func getAttachmentName(filename, suffix string) string {
 
 	nameParts := strings.Split(nameWithoutExt, "-")
 
-	updatedName := nameParts[0] + "-" + suffix
+	prefix := nameParts[0]
+	if slices.Contains(nameParts[1:], "frontend") {
+		prefix += "-frontend"
+	}
+
+	updatedName := prefix + "-" + suffix
 	return fmt.Sprintf("%s.%s", updatedName, ext)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -107,7 +107,6 @@ func Serve(dbUrl string, natsUrl string) error {
 		r.Post("/missingData", meta.CreatePostMissingDataRequestHandler(dbpool))
 		r.Route("/youtrack", func(r chi.Router) {
 			r.Post("/createIssue", meta.CreatePostCreateIssueByAccident(dbpool))
-			r.Post("/uploadAttachments", meta.CreatePostUploadAttachmentsToIssue())
 		})
 		r.Route("/teamcity", func(r chi.Router) {
 			r.Post("/startBisect", meta.CreatePostStartBisect())
@@ -118,6 +117,7 @@ func Serve(dbUrl string, natsUrl string) error {
 			r.Get("/buildInfo", meta.HandleGetTeamCityBuildInfo())
 			r.Get("/artifactsExist", meta.HandleGetTeamCityArtifactsExist())
 		})
+		r.Post("/uploadAttachments", meta.CreatePostUploadAttachments())
 	})
 
 	router.Route("/api/auth", func(r chi.Router) {


### PR DESCRIPTION
important: upload to one target should not block uploads to other ones

added upload of degradation data as a file to keep in artifacts for analysis (TC param left for now as possible fallback in case of artifacts download error)