### PR TITLE
Add option to merge branches on charts

### DIFF
--- a/dashboard/new-dashboard/src/components/common/DataQueryExecutor.ts
+++ b/dashboard/new-dashboard/src/components/common/DataQueryExecutor.ts
@@ -123,21 +123,30 @@ export function generateQueries(query: DataQuery, configuration: DataQueryExecut
     // each column value it is an index of producer value
     let seriesName = ""
     let measureName = ""
+    const metadata: { isBranchDimension: boolean; measureName: string; seriesName: string }[] = []
     for (const [i, index] of item.entries()) {
       const producer = producers[i]
       producer.mutate(index)
+      const producerMeasureName = producer.getMeasureName(index)
+      const producerSeriesName = producer.getSeriesName(index)
       if (i !== 0) {
         measureName += " – "
       }
-      measureName += producer.getMeasureName(index)
+      measureName += producerMeasureName
 
-      const title = producer.getSeriesName(index)
+      const title = producerSeriesName
       if (title.length > 0) {
         if (seriesName.length > 0) {
           seriesName += " – "
         }
         seriesName += title
       }
+
+      metadata.push({
+        isBranchDimension: producer.isBranchDimension === true,
+        measureName: producerMeasureName,
+        seriesName: producerSeriesName,
+      })
     }
 
     serializedQuery.push(structuredClone(query))
@@ -162,6 +171,7 @@ export function generateQueries(query: DataQuery, configuration: DataQueryExecut
 
     configuration.seriesNames.push(seriesName)
     configuration.measureNames.push(measureName)
+    configuration.seriesMetadata.push(metadata)
   }
 
   if (serializedQuery.length > 0) {

--- a/dashboard/new-dashboard/src/components/common/dataQuery.ts
+++ b/dashboard/new-dashboard/src/components/common/dataQuery.ts
@@ -124,6 +124,8 @@ export interface ServerConfigurator extends DataQueryConfigurator {
 }
 
 export interface QueryProducer {
+  isBranchDimension?: boolean
+
   size(): number
 
   /**
@@ -156,6 +158,7 @@ export class SimpleQueryProducer implements QueryProducer {
 export class DataQueryExecutorConfiguration {
   public seriesNames: string[] = []
   readonly measureNames: string[] = []
+  readonly seriesMetadata: { isBranchDimension: boolean; measureName: string; seriesName: string }[][] = []
 
   readonly queryProducers: QueryProducer[] = []
 

--- a/dashboard/new-dashboard/src/components/settings/GroupBranchesIntoSingleChartSwitch.vue
+++ b/dashboard/new-dashboard/src/components/settings/GroupBranchesIntoSingleChartSwitch.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="flex items-center justify-between w-full">
+    <span v-tooltip.left="'Merge selected branches into one series for each metric'">Merge branches:</span>
+    <ToggleSwitch
+      v-model="settingsStore.groupBranchesIntoSingleChart"
+      class="ml-4"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useSettingsStore } from "./settingsStore"
+
+const settingsStore = useSettingsStore()
+</script>
+
+<style scoped></style>

--- a/dashboard/new-dashboard/src/components/settings/PlotSettings.vue
+++ b/dashboard/new-dashboard/src/components/settings/PlotSettings.vue
@@ -14,6 +14,7 @@
     <DetectChangesSwitch class="mb-2" />
     <FlexibleZeroOnYAxis class="mb-2" />
     <RemoveOutliersSwitch class="mb-2" />
+    <GroupBranchesIntoSingleChartSwitch class="mb-2" />
     <FadeOnHoverSwitch />
   </Popover>
 </template>
@@ -30,6 +31,7 @@ import FlexibleZeroOnYAxis from "./FlexibleYZeroSwitch.vue"
 import { FlexibleZeroOnYAxisConfigurator } from "./configurators/FlexibleZeroOnYAxisConfigurator"
 import RemoveOutliersSwitch from "./RemoveOutliersSwitch.vue"
 import FadeOnHoverSwitch from "./FadeOnHoverSwitch.vue"
+import GroupBranchesIntoSingleChartSwitch from "./GroupBranchesIntoSingleChartSwitch.vue"
 import { RemoveOutliersConfigurator } from "./configurators/RemoveOutliersConfigurator"
 import { useSettingsStore } from "./settingsStore"
 import { storeToRefs } from "pinia"

--- a/dashboard/new-dashboard/src/components/settings/settingsStore.ts
+++ b/dashboard/new-dashboard/src/components/settings/settingsStore.ts
@@ -9,6 +9,7 @@ export const useSettingsStore = defineStore("settingsStore", () => {
   const storedFlexibleYZero = useStorage("floatingNull", false)
   const storedRemoveOutliers = useStorage("removeOutliers", false)
   const storedGroupBranches = useStorage("groupBranches", true)
+  const storedGroupBranchesIntoSingleChart = useStorage("groupBranchesIntoSingleChart", false)
   const storedFadeOnHover = useStorage("fadeOnHover", false)
 
   const scaling = computed({
@@ -55,6 +56,13 @@ export const useSettingsStore = defineStore("settingsStore", () => {
     },
   })
 
+  const groupBranchesIntoSingleChart = computed({
+    get: () => storedGroupBranchesIntoSingleChart.value,
+    set(value) {
+      storedGroupBranchesIntoSingleChart.value = value
+    },
+  })
+
   const fadeOnHover = computed({
     get: () => storedFadeOnHover.value,
     set(value) {
@@ -62,5 +70,5 @@ export const useSettingsStore = defineStore("settingsStore", () => {
     },
   })
 
-  return { scaling, smoothing, detectChanges, flexibleYZero, removeOutliers, groupBranches, fadeOnHover }
+  return { scaling, smoothing, detectChanges, flexibleYZero, removeOutliers, groupBranches, groupBranchesIntoSingleChart, fadeOnHover }
 })

--- a/dashboard/new-dashboard/src/configurators/BranchConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/BranchConfigurator.ts
@@ -48,6 +48,7 @@ export class BranchConfigurator extends DimensionConfigurator {
     const filter: DataQueryFilter = { f: this.name, v: "" }
     const values = Array.isArray(value) ? [...value] : [value]
     configuration.queryProducers.push({
+      isBranchDimension: true,
       size(): number {
         return values.length
       },

--- a/dashboard/new-dashboard/src/configurators/MeasureConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/MeasureConfigurator.ts
@@ -3,7 +3,7 @@ import { DatasetOption, ECBasicOption, ZRColor } from "echarts/types/dist/shared
 import type { DefaultLabelFormatterCallbackParams as CallbackDataParams } from "echarts"
 import { deepEqual } from "fast-equals"
 import { combineLatest, debounceTime, distinctUntilChanged, forkJoin, map, Observable, of, switchMap } from "rxjs"
-import { ref, Ref, shallowRef } from "vue"
+import { ref, Ref, shallowRef, toRef } from "vue"
 import { DataQueryResult } from "../components/common/DataQueryExecutor"
 import { PersistentStateManager } from "../components/common/PersistentStateManager"
 import { ChartConfigurator, ChartType, collator, SymbolOptions, ValueUnit } from "../components/common/chart"
@@ -50,7 +50,7 @@ export class MeasureConfigurator implements DataQueryConfigurator, ChartConfigur
   readonly showAllMetrics = ref(false)
 
   createObservable(): Observable<unknown> {
-    return refToObservable(this.selected, true)
+    return combineLatest([refToObservable(this.selected, true), refToObservable(toRef(useSettingsStore(), "groupBranchesIntoSingleChart"))])
   }
 
   setSelected(value: string[] | string | null) {
@@ -263,7 +263,7 @@ export class PredefinedMeasureConfigurator implements DataQueryConfigurator, Cha
   ) {}
 
   createObservable(): Observable<unknown> {
-    return combineLatest([refToObservable(this.skipZeroValues), refToObservable(this.measures)])
+    return combineLatest([refToObservable(this.skipZeroValues), refToObservable(this.measures), refToObservable(toRef(useSettingsStore(), "groupBranchesIntoSingleChart"))])
   }
 
   configureQuery(query: DataQuery, configuration: DataQueryExecutorConfiguration): boolean {
@@ -448,7 +448,50 @@ class MergeResults {
   }
 }
 
-function mergeSeries(dataList: (string | number)[][][], configuration: DataQueryExecutorConfiguration) {
+function sortSeriesDataByTime(seriesData: (string | number)[][]): (string | number)[][] {
+  if (seriesData.length === 0 || seriesData[0].length < 2) {
+    return seriesData
+  }
+
+  const order = seriesData[0].map((_, index) => index).toSorted((left, right) => Number(seriesData[0][left]) - Number(seriesData[0][right]))
+
+  return seriesData.map((row) => order.map((index) => row[index]))
+}
+
+function toSeriesMeta(measureName: string, seriesName: string) {
+  return {
+    id: measureName === seriesName ? seriesName : `${measureName}@${seriesName}`,
+    seriesName,
+    measureName,
+  }
+}
+
+function getSeriesMeta(dataIndex: number, configuration: DataQueryExecutorConfiguration) {
+  const rawSeriesName = configuration.seriesNames[dataIndex]
+  const rawMeasureName = configuration.measureNames[dataIndex]
+  return toSeriesMeta(rawMeasureName, rawSeriesName)
+}
+
+function getBranchMergedSeriesMeta(dataIndex: number, configuration: DataQueryExecutorConfiguration) {
+  const metadata = configuration.seriesMetadata[dataIndex]
+  if (metadata == null || metadata.length === 0) return getSeriesMeta(dataIndex, configuration)
+
+  const buildCompositeName = (field: "measureName" | "seriesName"): string => {
+    const parts = metadata
+      .filter((entry) => !entry.isBranchDimension)
+      .map((entry) => entry[field])
+      .filter((entry) => entry.length > 0)
+    return parts.join(" – ")
+  }
+
+  const rawMeasureName = configuration.measureNames[dataIndex]
+  const measureName = buildCompositeName("measureName") || rawMeasureName
+  const seriesName = buildCompositeName("seriesName") || measureName
+
+  return toSeriesMeta(measureName, seriesName)
+}
+
+function mergeSeries(dataList: (string | number)[][][], configuration: DataQueryExecutorConfiguration, groupBranchesIntoSingleChart: boolean) {
   const mergedDataList: DataQueryResult = []
   const seriesIdsToIndex = new Map<string, number>()
   const seriesIdToSeriesName = new Map<number, string>()
@@ -458,8 +501,9 @@ function mergeSeries(dataList: (string | number)[][][], configuration: DataQuery
       console.log("Serie is empty and will be hidden: " + configuration.seriesNames[dataIndex])
       continue
     }
-    const measureName = configuration.measureNames[dataIndex]
-    let seriesName = configuration.seriesNames[dataIndex]
+    const mergedSeriesMeta = groupBranchesIntoSingleChart ? getBranchMergedSeriesMeta(dataIndex, configuration) : getSeriesMeta(dataIndex, configuration)
+    const measureName = mergedSeriesMeta.measureName
+    let seriesName = mergedSeriesMeta.seriesName
     //fleet
     if (seriesName == "" && (seriesData.length == 6 || seriesData.length == 10)) {
       seriesName = seriesData[4][0] as string
@@ -468,13 +512,14 @@ function mergeSeries(dataList: (string | number)[][][], configuration: DataQuery
       seriesName = seriesData[6][0] as string
     }
     seriesName = measureNameToLabel(seriesName)
-    const id = measureName === seriesName ? seriesName : `${measureName}@${seriesName}`
+    const id = mergedSeriesMeta.id
     if (seriesIdsToIndex.has(id)) {
       const seriesIndex = seriesIdsToIndex.get(id) as number
       const values = mergedDataList[seriesIndex]
       for (const [i, seriesDatum] of seriesData.entries()) {
         values[i] = i < values.length ? [...values[i], ...seriesDatum] : [...seriesDatum]
       }
+      mergedDataList[seriesIndex] = sortSeriesDataByTime(values)
     } else {
       const newId = mergedDataList.push(seriesData) - 1
       seriesIdsToIndex.set(id, newId)
@@ -504,9 +549,8 @@ async function configureChart(
   const dataset: DatasetOption[] = []
 
   //merge series with the same name
-  const mergeResults = mergeSeries(dataList, configuration)
-
   const settings = useSettingsStore()
+  const mergeResults = mergeSeries(dataList, configuration, settings.groupBranchesIntoSingleChart)
   // eslint-disable-next-line prefer-const
   for (let [dataIndex, seriesData] of mergeResults.data.entries()) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition


### PR DESCRIPTION
When enabled, charts combine series that differ only by branch while keeping other dimensions separate. This is useful when comparing feature branches with master