### PR TITLE
[kotlin] Add missing entries for Code Typing test metrics

### DIFF
--- a/dashboard/new-dashboard/src/shared/metricsDescription.ts
+++ b/dashboard/new-dashboard/src/shared/metricsDescription.ts
@@ -52,6 +52,11 @@ export const metricsDescription: Map<string, string | MetricInfo> = new Map<stri
   //completion
   ["completion", "Total time of each completion invocation in test. Completion invocation time is a time that it takes to load all completion variants."],
   ["completion#mean_value", "Mean value of all completion invocation in test. Completion invocation time is a time that it takes to load all completion variants."],
+  //code typing
+  [
+    "codeTyping#mean_value",
+    "Mean time of a code typing iteration. A code typing test types a piece of code with medium complexity from beginning to end, invoking completion and waiting for code analysis at predetermined points.",
+  ],
   //find usages
   ["findUsage_popup", "Time to show the find usages popup"],
   ["findUsages", "Time to show all usages in the popup"],

--- a/pkg/degradation-detector/setting/kotlinSettings.go
+++ b/pkg/degradation-detector/setting/kotlinSettings.go
@@ -55,6 +55,7 @@ func GenerateKotlinSettings() []detector.PerformanceSettings {
 		"localInspections_cold#mean_value", "localInspections_hot#mean_value",
 		"execute_editor_gotodeclaration_cold#mean_value", "execute_editor_gotodeclaration_hot#mean_value",
 		"convertJavaToKotlin", "moveFiles#mean_value", "moveFiles_back#mean_value", "moveDeclarations#mean_value", "moveDeclarations_back#mean_value",
+		"codeTyping#mean_value",
 	}
 	aliases := map[string]string{
 		"completion#mean_value":                          "completion",
@@ -74,6 +75,7 @@ func GenerateKotlinSettings() []detector.PerformanceSettings {
 		"localInspections_hot#mean_value":                "highlighting_hot_cache",
 		"convertJavaToKotlin":                            "J2K",
 		"moveFiles#mean_value":                           "moveFiles",
+		"codeTyping#mean_value":                          "codeTyping",
 	}
 	settings := make([]detector.PerformanceSettings, 0, len(testNames)*len(metrics)*2)
 


### PR DESCRIPTION
Add missing entries for Code Typing test metrics to the degradation detector and metrics descriptions.

^KT-82174