### PR TITLE
collect changes for fleet/measure_new

### DIFF
--- a/dashboard/new-dashboard/src/components/common/uploadAttachments/uploadAttachmentsUtils.ts
+++ b/dashboard/new-dashboard/src/components/common/uploadAttachments/uploadAttachmentsUtils.ts
@@ -7,6 +7,7 @@ export interface UploadAttachmentsRequest {
   }
   projectName: string
   testType: string
+  methodName?: string
 }
 
 export interface YoutrackUploadAttachmentsRequest extends UploadAttachmentsRequest {

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
@@ -319,7 +319,7 @@ async function createTicket() {
     },
     projectName: data.projectName,
     testType: dbTypeStore().dbType,
-    methodName: data.description.value?.methodName?.replaceAll("#", "."),
+    methodName: data.description.value?.methodName ?? undefined,
   }
   let chartPng: string | undefined
   if (accident.kind != AccidentKind.Exception) {

--- a/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
+++ b/dashboard/new-dashboard/src/components/common/youtrack/YoutrackDialog.vue
@@ -319,6 +319,7 @@ async function createTicket() {
     },
     projectName: data.projectName,
     testType: dbTypeStore().dbType,
+    methodName: data.description.value?.methodName?.replaceAll("#", "."),
   }
   let chartPng: string | undefined
   if (accident.kind != AccidentKind.Exception) {

--- a/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
@@ -100,7 +100,7 @@ export class LlmAnalysesConfigurator {
       },
       projectName: data.projectName,
       testType: dbTypeStore().dbType,
-      methodName: data.description.value?.methodName?.replaceAll("#", "."),
+      methodName: data.description.value?.methodName ?? undefined,
     }
     const spaceAttachments = await uploadAttachmentsToSpace(serverConfigurator, attachmentsInfo)
     const { firstCommit, lastCommit } = await getFirstAndLastCommit(serverConfigurator.db, data.installerId ?? data.buildId)
@@ -116,7 +116,7 @@ export class LlmAnalysesConfigurator {
       userName: useUserStore().user?.name ?? undefined,
       firstCommitRevision: firstCommit ?? undefined,
       lastCommitRevision: lastCommit ?? undefined,
-      testMethodName: data.description.value?.methodName ?? undefined,
+      testMethodName: data.description.value?.methodName?.replaceAll("#", "."),
       ytIssueId: ytIssueId ?? undefined,
       dashboardLink,
     }

--- a/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
@@ -100,6 +100,7 @@ export class LlmAnalysesConfigurator {
       },
       projectName: data.projectName,
       testType: dbTypeStore().dbType,
+      methodName: data.description.value?.methodName?.replaceAll("#", "."),
     }
     const spaceAttachments = await uploadAttachmentsToSpace(serverConfigurator, attachmentsInfo)
     const { firstCommit, lastCommit } = await getFirstAndLastCommit(serverConfigurator.db, data.installerId ?? data.buildId)

--- a/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/llmAnalyses/LlmAnalysesConfigurator.ts
@@ -116,7 +116,7 @@ export class LlmAnalysesConfigurator {
       userName: useUserStore().user?.name ?? undefined,
       firstCommitRevision: firstCommit ?? undefined,
       lastCommitRevision: lastCommit ?? undefined,
-      testMethodName: data.description.value?.methodName?.replaceAll("#", "."),
+      testMethodName: data.description.value?.methodName ?? undefined,
       ytIssueId: ytIssueId ?? undefined,
       dashboardLink,
     }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -129,6 +129,7 @@ func GetAnalyzer(id string) DatabaseConfiguration {
 			TableName:                   "measure_new",
 			ReportReader:                analyzePerfFleetReport,
 			HasNoInstallerButHasChanges: true,
+			HasMetaDB:                   true,
 			extraFieldCount:             3,
 			insertStatementWriter: func(sb *strings.Builder) {
 				sb.WriteString(", measures.name, measures.value, measures.type")

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -125,10 +125,11 @@ func GetAnalyzer(id string) DatabaseConfiguration {
 		}
 	case id == "perf_fleet":
 		return DatabaseConfiguration{
-			DbName:          "fleet",
-			TableName:       "measure_new",
-			ReportReader:    analyzePerfFleetReport,
-			extraFieldCount: 3,
+			DbName:                      "fleet",
+			TableName:                   "measure_new",
+			ReportReader:                analyzePerfFleetReport,
+			HasNoInstallerButHasChanges: true,
+			extraFieldCount:             3,
 			insertStatementWriter: func(sb *strings.Builder) {
 				sb.WriteString(", measures.name, measures.value, measures.type")
 			},

--- a/pkg/analyzer/fleetReport.go
+++ b/pkg/analyzer/fleetReport.go
@@ -21,6 +21,10 @@ func analyzePerfFleetReport(runResult *RunResult, data *fastjson.Value) error {
 	first := values[0]
 	runResult.GeneratedTime = time.Unix(0, first.GetInt64("epochNanos"))
 	runResult.Report.Project = strings.ReplaceAll(filepath.Base(filepath.Dir(runResult.ReportFileName)), "%20", " ")
+	runResult.Report.MethodName = string(first.GetStringBytes("attributes", "test.name"))
+	if runResult.Report.MethodName == "" {
+		runResult.Report.MethodName = runResult.Report.Project
+	}
 
 	fileName := filepath.Base(runResult.ReportFileName)
 	metricNames := make([]string, 0)

--- a/pkg/analyzer/fleetReport.go
+++ b/pkg/analyzer/fleetReport.go
@@ -22,9 +22,6 @@ func analyzePerfFleetReport(runResult *RunResult, data *fastjson.Value) error {
 	runResult.GeneratedTime = time.Unix(0, first.GetInt64("epochNanos"))
 	runResult.Report.Project = strings.ReplaceAll(filepath.Base(filepath.Dir(runResult.ReportFileName)), "%20", " ")
 	runResult.Report.MethodName = string(first.GetStringBytes("attributes", "test.name"))
-	if runResult.Report.MethodName == "" {
-		runResult.Report.MethodName = runResult.Report.Project
-	}
 
 	fileName := filepath.Base(runResult.ReportFileName)
 	metricNames := make([]string, 0)

--- a/pkg/server/meta/artifactsCollector.go
+++ b/pkg/server/meta/artifactsCollector.go
@@ -55,7 +55,8 @@ type fleetPerfTestCollector struct{}
 
 func (f fleetPerfTestCollector) getArtifactsPaths(params UploadAttachmentsRequest) []string {
 	if params.MethodName == nil {
-		return nil
+		// fallback to situations when MethodName is not provided
+		return []string{""}
 	}
 	artifactPath := *params.MethodName
 	testMethodName := artifactPath
@@ -68,7 +69,8 @@ func (f fleetPerfTestCollector) getArtifactsPaths(params UploadAttachmentsReques
 
 func (f fleetPerfTestCollector) checkArtifact(artifactName string) bool {
 	switch artifactName {
-	case "fsdaemon.log", "fleet.log", "spans.json", "fleet.test.json":
+	// logs.zip is fallback for situation when MethodName is not provided and we just download logs.zip from the root
+	case "logs.zip", "fsdaemon.log", "fleet.log", "spans.json", "fleet.test.json":
 		return true
 	default:
 		return false

--- a/pkg/server/meta/artifactsCollector.go
+++ b/pkg/server/meta/artifactsCollector.go
@@ -63,7 +63,7 @@ func (f fleetPerfTestCollector) getArtifactsPaths(params UploadAttachmentsReques
 	if _, after, ok := strings.Cut(methodName, "#"); ok {
 		testMethodName = after
 	}
-	return []string{"logs.zip!/" + artifactPath, "logs.zip!/" + artifactPath + "/fsdaemon", "metrics/" + testMethodName}
+	return []string{"logs/" + artifactPath, "metrics/" + testMethodName}
 }
 
 func (f fleetPerfTestCollector) checkArtifact(artifactName string) bool {

--- a/pkg/server/meta/artifactsCollector.go
+++ b/pkg/server/meta/artifactsCollector.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"slices"
 	"strings"
@@ -127,28 +126,22 @@ func getArtifactCollector(testType string) artifactCollector {
 }
 
 func getAttachmentName(filename, suffix string) string {
-	// Handle metrics.performance.json specially
-	if strings.HasPrefix(filename, "metrics.performance") && strings.HasSuffix(filename, ".json") {
-		return fmt.Sprintf("metrics.performance-%s.json", suffix)
+	name, ext := filename, ""
+	if dot := strings.LastIndex(filename, "."); dot > 0 {
+		name, ext = filename[:dot], filename[dot+1:]
 	}
 
-	parts := strings.Split(filename, ".")
-	if len(parts) != 2 {
-		return filename
-	}
-
-	nameWithoutExt := parts[0]
-	ext := parts[1]
-
-	nameParts := strings.Split(nameWithoutExt, "-")
-
+	nameParts := strings.Split(name, "-")
 	prefix := nameParts[0]
 	if slices.Contains(nameParts[1:], "frontend") {
 		prefix += "-frontend"
 	}
 
-	updatedName := prefix + "-" + suffix
-	return fmt.Sprintf("%s.%s", updatedName, ext)
+	result := prefix + "-" + suffix
+	if ext != "" {
+		result += "." + ext
+	}
+	return result
 }
 
 // ProcessAndUploadTeamcityArtifacts handles the common logic for fetching artifacts
@@ -189,6 +182,14 @@ func processBuildsArtifacts(
 	config UploadConfig,
 	uploadWg *sync.WaitGroup,
 ) {
+	var attachmentPostfix string
+	if !config.SkipPostfix {
+		if index == 0 {
+			attachmentPostfix = "current"
+		} else {
+			attachmentPostfix = "before"
+		}
+	}
 	for _, testArtifactPath := range collector.getArtifactsPaths(params) {
 		children, err := teamCityClient.getArtifactChildren(ctx, buildId, testArtifactPath)
 		if err != nil {
@@ -200,15 +201,6 @@ func processBuildsArtifacts(
 		for _, str := range children {
 			if collector.checkArtifact(str) {
 				filteredChildren = append(filteredChildren, str)
-			}
-		}
-
-		var attachmentPostfix string
-		if !config.SkipPostfix {
-			if index == 0 {
-				attachmentPostfix = "current"
-			} else {
-				attachmentPostfix = "before"
 			}
 		}
 

--- a/pkg/server/meta/artifactsCollector.go
+++ b/pkg/server/meta/artifactsCollector.go
@@ -13,6 +13,7 @@ type UploadAttachmentsRequest struct {
 	TeamCityAttachmentInfo TeamCityAttachmentInfo `json:"teamcityAttachmentInfo"`
 	ProjectName            string                 `json:"projectName"`
 	TestType               string                 `json:"testType"`
+	MethodName             *string                `json:"methodName,omitempty"`
 }
 
 type teamCityArtifact struct {
@@ -36,14 +37,14 @@ type UploadConfig struct {
 }
 
 type artifactCollector interface {
-	getArtifactsPath(params UploadAttachmentsRequest) string
+	getArtifactsPaths(params UploadAttachmentsRequest) []string
 	checkArtifact(artifactName string) bool
 }
 
 type fleetStartupCollector struct{}
 
-func (f fleetStartupCollector) getArtifactsPath(UploadAttachmentsRequest) string {
-	return ""
+func (f fleetStartupCollector) getArtifactsPaths(UploadAttachmentsRequest) []string {
+	return []string{""}
 }
 
 func (f fleetStartupCollector) checkArtifact(artifactName string) bool {
@@ -52,18 +53,32 @@ func (f fleetStartupCollector) checkArtifact(artifactName string) bool {
 
 type fleetPerfTestCollector struct{}
 
-func (f fleetPerfTestCollector) getArtifactsPath(UploadAttachmentsRequest) string {
-	return ""
+func (f fleetPerfTestCollector) getArtifactsPaths(params UploadAttachmentsRequest) []string {
+	if params.MethodName == nil {
+		return nil
+	}
+	artifactPath := *params.MethodName
+	testMethodName := artifactPath
+	if idx := strings.LastIndex(artifactPath, "."); idx != -1 {
+		testMethodName = artifactPath[idx+1:]
+		artifactPath = artifactPath[:idx] + "/" + testMethodName
+	}
+	return []string{"logs.zip!/" + artifactPath, "logs.zip!/" + artifactPath + "/fsdaemon", "metrics/" + testMethodName}
 }
 
 func (f fleetPerfTestCollector) checkArtifact(artifactName string) bool {
-	return artifactName == "logs.zip"
+	switch artifactName {
+	case "fsdaemon.log", "fleet.log", "spans.json", "fleet.test.json":
+		return true
+	default:
+		return false
+	}
 }
 
 type perfUnitTestCollector struct{}
 
-func (f perfUnitTestCollector) getArtifactsPath(params UploadAttachmentsRequest) string {
-	return params.ProjectName
+func (f perfUnitTestCollector) getArtifactsPaths(params UploadAttachmentsRequest) []string {
+	return []string{params.ProjectName}
 }
 
 func (f perfUnitTestCollector) checkArtifact(artifactName string) bool {
@@ -77,8 +92,8 @@ func (f perfUnitTestCollector) checkArtifact(artifactName string) bool {
 
 type perfintCollector struct{}
 
-func (f perfintCollector) getArtifactsPath(params UploadAttachmentsRequest) string {
-	return strings.ReplaceAll(params.ProjectName, "_", "-")
+func (f perfintCollector) getArtifactsPaths(params UploadAttachmentsRequest) []string {
+	return []string{strings.ReplaceAll(params.ProjectName, "_", "-")}
 }
 
 func (f perfintCollector) checkArtifact(artifactName string) bool {
@@ -172,58 +187,58 @@ func processBuildsArtifacts(
 	config UploadConfig,
 	uploadWg *sync.WaitGroup,
 ) {
-	testArtifactPath := collector.getArtifactsPath(params)
-
-	children, err := teamCityClient.getArtifactChildren(ctx, buildId, testArtifactPath)
-	if err != nil {
-		config.OnError(buildId, "Failed to get teamcity artifact children", err)
-		return
-	}
-
-	var filteredChildren []string
-	for _, str := range children {
-		if collector.checkArtifact(str) {
-			filteredChildren = append(filteredChildren, str)
+	for _, testArtifactPath := range collector.getArtifactsPaths(params) {
+		children, err := teamCityClient.getArtifactChildren(ctx, buildId, testArtifactPath)
+		if err != nil {
+			config.OnError(buildId, "Failed to get teamcity artifact children", err)
+			continue
 		}
-	}
 
-	var attachmentPostfix string
-	if !config.SkipPostfix {
-		if index == 0 {
-			attachmentPostfix = "current"
-		} else {
-			attachmentPostfix = "before"
+		var filteredChildren []string
+		for _, str := range children {
+			if collector.checkArtifact(str) {
+				filteredChildren = append(filteredChildren, str)
+			}
 		}
-	}
 
-	for _, str := range filteredChildren {
-		fileName := str
+		var attachmentPostfix string
 		if !config.SkipPostfix {
-			fileName = getAttachmentName(str, attachmentPostfix)
-		}
-		artifact := teamCityArtifact{
-			BuildId:      buildId,
-			ArtifactPath: testArtifactPath + "/" + str,
-		}
-		uploadWg.Go(func() {
-			resp, err := teamCityClient.getDownloadArtifactResponse(ctx, artifact.BuildId, artifact.ArtifactPath)
-			if err != nil {
-				config.OnError(artifact.BuildId, "Failed to download artifact from TeamCity", err)
-				return
-			}
-			defer resp.Body.Close()
-
-			err = config.UploadArtifact(ctx, UploadArtifact{
-				BuildId:       artifact.BuildId,
-				FileName:      fileName,
-				Body:          resp.Body,
-				ContentLength: resp.ContentLength,
-			})
-			if err != nil {
-				config.OnError(artifact.BuildId, "Failed to upload attachment", err)
+			if index == 0 {
+				attachmentPostfix = "current"
 			} else {
-				config.OnSuccess(artifact.BuildId, fileName)
+				attachmentPostfix = "before"
 			}
-		})
+		}
+
+		for _, str := range filteredChildren {
+			fileName := str
+			if !config.SkipPostfix {
+				fileName = getAttachmentName(str, attachmentPostfix)
+			}
+			artifact := teamCityArtifact{
+				BuildId:      buildId,
+				ArtifactPath: testArtifactPath + "/" + str,
+			}
+			uploadWg.Go(func() {
+				resp, err := teamCityClient.getDownloadArtifactResponse(ctx, artifact.BuildId, artifact.ArtifactPath)
+				if err != nil {
+					config.OnError(artifact.BuildId, "Failed to download artifact from TeamCity", err)
+					return
+				}
+				defer resp.Body.Close()
+
+				err = config.UploadArtifact(ctx, UploadArtifact{
+					BuildId:       artifact.BuildId,
+					FileName:      fileName,
+					Body:          resp.Body,
+					ContentLength: resp.ContentLength,
+				})
+				if err != nil {
+					config.OnError(artifact.BuildId, "Failed to upload attachment", err)
+				} else {
+					config.OnSuccess(artifact.BuildId, fileName)
+				}
+			})
+		}
 	}
 }

--- a/pkg/server/meta/artifactsCollector.go
+++ b/pkg/server/meta/artifactsCollector.go
@@ -58,11 +58,11 @@ func (f fleetPerfTestCollector) getArtifactsPaths(params UploadAttachmentsReques
 		// fallback to situations when MethodName is not provided
 		return []string{""}
 	}
-	artifactPath := *params.MethodName
-	testMethodName := artifactPath
-	if idx := strings.LastIndex(artifactPath, "."); idx != -1 {
-		testMethodName = artifactPath[idx+1:]
-		artifactPath = artifactPath[:idx] + "/" + testMethodName
+	methodName := *params.MethodName
+	artifactPath := strings.ReplaceAll(methodName, "#", "/")
+	testMethodName := methodName
+	if _, after, ok := strings.Cut(methodName, "#"); ok {
+		testMethodName = after
 	}
 	return []string{"logs.zip!/" + artifactPath, "logs.zip!/" + artifactPath + "/fsdaemon", "metrics/" + testMethodName}
 }


### PR DESCRIPTION
changes are not written to the fleet.installer table for "perf_fleet" config. it causes missing commits range in llm analysis.

I checked configurations for `perf_fleet` looks like `HasNoInstallerButHasChanges: true` works ok for them, because even when they depend on installer build they share vcs snapshot