### PR TITLE
PY-89127 python: Add Performance Unit Tests (Code Insight)

### DIFF
--- a/dashboard/new-dashboard/src/components/pycharm/PyPerfUnitTests.vue
+++ b/dashboard/new-dashboard/src/components/pycharm/PyPerfUnitTests.vue
@@ -1,0 +1,140 @@
+<template>
+  <DashboardPage
+    db-name="perfUnitTests"
+    table="report"
+    persistent-id="py_perf_unit_tests"
+    initial-machine="linux-blade-hetzner"
+    :with-installer="false"
+  >
+    <Divider label="Pandas" />
+    <section class="flex gap-6">
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Completion: pandas/groupBy"
+          measure="attempt.median.ms"
+          :projects="[
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testCompletionInGroupBy - PyCharm',
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testCompletionInGroupBy - Pyrefly',
+          ]"
+          :legend-formatter="legendFormatter"
+        />
+      </div>
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Completion: pandas/merge"
+          measure="attempt.median.ms"
+          :projects="[
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testCompletionInMerge - PyCharm',
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testCompletionInMerge - Pyrefly',
+          ]"
+          :legend-formatter="legendFormatter"
+        />
+      </div>
+    </section>
+    <section class="flex gap-6">
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Typing Code Analysis: pandas/groupBy"
+          measure="attempt.median.ms"
+          :projects="[
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testTypingCodeAnalysisGroupBy - PyCharm',
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testTypingCodeAnalysisGroupBy - Pyrefly',
+          ]"
+          :legend-formatter="legendFormatter"
+        />
+      </div>
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Typing Code Analysis: pandas/merge"
+          measure="attempt.median.ms"
+          :projects="[
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testTypingCodeAnalysisMerge - PyCharm',
+            'com.intellij.python.junit5Tests.performance.PyPandasExamplesPerformanceTest.testTypingCodeAnalysisMerge - Pyrefly',
+          ]"
+          :legend-formatter="legendFormatter"
+        />
+      </div>
+    </section>
+    <section>
+      <GroupProjectsWithClientChart
+        label="Typing-with-completion"
+        measure="attempt.median.ms"
+        :projects="[
+          'com.intellij.python.junit5Tests.performance.PyPandasTypingPerformanceTest.testPandas233 - PyCharm',
+          'com.intellij.python.junit5Tests.performance.PyPandasTypingPerformanceTest.testPandas300rc0 - PyCharm',
+        ]"
+      />
+    </section>
+
+    <Divider label="Boto3" />
+    <section class="flex gap-6">
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Completion: boto3/resource.py"
+          measure="attempt.median.ms"
+          :projects="['com.intellij.python.junit5Tests.performance.PyBoto3PerformanceTest.testResourceCompletion - PyCharm']"
+        />
+      </div>
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Completion: boto3/client.py"
+          measure="attempt.median.ms"
+          :projects="['com.intellij.python.junit5Tests.performance.PyBoto3PerformanceTest.testClientCompletion - PyCharm']"
+        />
+      </div>
+    </section>
+
+    <Divider label="Generative" />
+    <section class="flex gap-6">
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Highlighting (after each type)"
+          measure="attempt.median.ms"
+          :projects="['com.intellij.python.junit5Tests.performance.PyHighlightingPerformanceTest.testGenerativeHighlighting - PyCharm']"
+        />
+      </div>
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Typing"
+          measure="attempt.median.ms"
+          :projects="['com.intellij.python.junit5Tests.performance.PyTypingPerformanceTest.testGenerativeTest - PyCharm']"
+        />
+      </div>
+      <div class="flex-1 min-w-0">
+        <GroupProjectsWithClientChart
+          label="Typing Code Analysis"
+          measure="attempt.median.ms"
+          :projects="['com.intellij.python.junit5Tests.performance.PyTypingCodeAnalysisPerformanceTest.testGenerativeTest - PyCharm']"
+        />
+      </div>
+    </section>
+
+    <Divider label="Other" />
+    <section>
+      <GroupProjectsWithClientChart
+        label="Completion: basic (venv)"
+        measure="attempt.median.ms"
+        :projects="['com.intellij.python.junit5Tests.performance.PyCompletionBasicPerformanceTest.testEmptyProjectWithVenv - PyCharm']"
+      />
+    </section>
+    <section>
+      <GroupProjectsWithClientChart
+        label="Completion: overloads"
+        measure="attempt.median.ms"
+        :projects="['com.intellij.python.junit5Tests.performance.PyOverloadsPerformanceTest.testCompletion - PyCharm']"
+      />
+    </section>
+  </DashboardPage>
+</template>
+
+<script setup lang="ts">
+import DashboardPage from "../common/DashboardPage.vue"
+import Divider from "../common/Divider.vue"
+import GroupProjectsWithClientChart from "../charts/GroupProjectsWithClientChart.vue"
+
+const legendFormatter = (name: string) => {
+  if (name.includes("- Pyrefly")) return "Pyrefly"
+  if (name.includes("- PyCharm")) return "PyCharm"
+  return name
+}
+</script>

--- a/dashboard/new-dashboard/src/routes.ts
+++ b/dashboard/new-dashboard/src/routes.ts
@@ -139,6 +139,7 @@ enum ROUTES {
   PyCharmDashboard = `${ROUTE_PREFIX.PyCharm}/${DASHBOARD_ROUTE}Dev`,
   PyCharmExternalTypeProviders = `${ROUTE_PREFIX.PyCharm}/externalTypeProviders`,
   PyCharmExternalTypeProvidersUnitPerfTests = `${ROUTE_PREFIX.PyCharm}/externalTypeProvidersUnitPerfTests`,
+  PyCharmPerfUnitTests = `${ROUTE_PREFIX.PyCharm}/perfUnitTests`,
   PyCharmOldDashboard = `${ROUTE_PREFIX.PyCharm}/${DASHBOARD_ROUTE}`,
   PyCharmTests = `${ROUTE_PREFIX.PyCharm}/${TEST_ROUTE}`,
   PyCharmDevTests = `${ROUTE_PREFIX.PyCharm}/${DEV_TEST_ROUTE}`,
@@ -710,6 +711,10 @@ const PYCHARM: Product = {
         {
           url: ROUTES.PyCharmExternalTypeProvidersUnitPerfTests,
           label: "External Type Providers Unit Performance Tests",
+        },
+        {
+          url: ROUTES.PyCharmPerfUnitTests,
+          label: "Performance Unit Tests",
         },
         {
           url: ROUTES.PyCharmOldDashboard,
@@ -1701,6 +1706,11 @@ const pycharmRoutes = [
     path: ROUTES.PyCharmExternalTypeProvidersUnitPerfTests,
     component: () => import("./components/pycharm/ExternalTypeProvidersUnitPerfTests.vue"),
     meta: { pageTitle: "PyCharm External Type Providers Unit Performance Tests dashboard" },
+  },
+  {
+    path: ROUTES.PyCharmPerfUnitTests,
+    component: () => import("./components/pycharm/PyPerfUnitTests.vue"),
+    meta: { pageTitle: "PyCharm Performance Unit Tests dashboard" },
   },
   {
     path: ROUTES.PyCharmOldDashboard,


### PR DESCRIPTION
Tests are grouped semantically (`pandas`, `boto3`, generative, other) rather than by class, so related benchmarks sit side-by-side. Where applicable, PyCharm and Pyrefly type engines are plotted on the same chart.

<img width="3840" height="10983" alt="Screenshot of PyCharm Performance Unit Tests dashboard" src="https://github.com/user-attachments/assets/7dac541d-9ff4-4826-964f-7ac0ff3ea219" />