### PR TITLE
Map qodana fleet agents to their own machine group so /qodana/tests opens on populated data

### DIFF
--- a/dashboard/new-dashboard/src/configurators/MachineConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/MachineConfigurator.ts
@@ -11,6 +11,10 @@ import { refToObservable } from "./rxjs"
 // todo what is it?
 const macLarge = "mac large"
 
+// Group name for the fleet-provisioned qodana heavy agents. Exported so getMachineGroupName and
+// the /qodana/tests route (initialMachine) reference one string and cannot drift apart.
+export const MACHINE_GROUP_QODANA_FLEET_HEAVY = "Linux EC2 c5.xlarge fleet (4 vCPU, 8 GB)"
+
 export class MachineConfigurator implements DataQueryConfigurator, FilterConfigurator {
   readonly selected = shallowRef<string[]>([])
   readonly values = shallowRef<GroupedDimensionValue[]>([])
@@ -82,6 +86,10 @@ export class MachineConfigurator implements DataQueryConfigurator, FilterConfigu
       const machineFromMap = MachineConfigurator.valueToGroup[value] as string | null
       if (groupName == "Unknown" && machineFromMap != null) {
         groupName = machineFromMap
+      } else if (groupName == "Unknown") {
+        // Surface unrecognised machines instead of silently bucketing them into "Unknown" — that
+        // silent path is how the renamed qodana fleet agents disappeared from the dashboard.
+        console.warn("MachineConfigurator: unrecognised machine, bucketed as Unknown:", value)
       }
 
       let item = this.groupNameToItem.get(groupName)
@@ -432,6 +440,12 @@ export function getMachineGroupName(machine: string): string {
   ) {
     // https://aws.amazon.com/ec2/instance-types/c5/
     groupName = "Linux EC2 c5.xlarge (4 vCPU, 8 GB)"
+  } else if (machine.startsWith("qodana-fleet-linux-amd64-heavy")) {
+    // Fleet agents in the `qodana-linux-amd64-heavy-*` hardware class, same 4 vCPU / 8 GB
+    // (metric values within ~1% for the same test). Kept as its own group instead of merged into
+    // "Linux EC2 c5.xlarge (4 vCPU, 8 GB)": a selected group is queried by its members' common prefix,
+    // and merging the two name-stems would collapse that to `qodana-`, matching every qodana class.
+    groupName = MACHINE_GROUP_QODANA_FLEET_HEAVY
   } else if (machine.startsWith("intellij-linux-2204-aws-c5ad-lt")) {
     // https://aws.amazon.com/ec2/instance-types/c5/
     groupName = "Linux EC2 (2204) c5.xlarge (4 vCPU, 8 GB)"

--- a/dashboard/new-dashboard/src/configurators/ServerWithCompressConfigurator.ts
+++ b/dashboard/new-dashboard/src/configurators/ServerWithCompressConfigurator.ts
@@ -7,10 +7,7 @@ import { injectOrError, serverUrlObservableKey } from "../shared/injectionKeys"
 export class ServerWithCompressConfigurator implements ServerConfigurator {
   static getDefaultServerUrl(): string {
     const hostname = window.location.hostname
-    if (hostname === "localhost") {
-      return ""
-    }
-    if (hostname === "ij-perf-api.labs.jb.gg") {
+    if (hostname === "ij-perf-api.labs.jb.gg" || hostname === "localhost") {
       return "https://ij-perf-api.labs.jb.gg"
     }
     return "https://ij-perf.labs.jb.gg"

--- a/dashboard/new-dashboard/src/routes.ts
+++ b/dashboard/new-dashboard/src/routes.ts
@@ -2,6 +2,7 @@
 
 import { ParentRouteRecord, TypedRouteRecord } from "./components/common/route"
 import { KOTLIN_MAIN_METRICS } from "./components/kotlin/projects"
+import { MACHINE_GROUP_QODANA_FLEET_HEAVY } from "./configurators/MachineConfigurator"
 import type { PerformanceTestsProps } from "./components/common/PerformanceTests.vue"
 
 const COMPONENTS = {
@@ -2203,7 +2204,7 @@ const qodanaRoutes = [
     props: {
       dbName: "qodana",
       table: "report",
-      initialMachine: "Linux EC2 c5a(d).xlarge (4 vCPU, 8 GB)",
+      initialMachine: MACHINE_GROUP_QODANA_FLEET_HEAVY,
       withInstaller: false,
     },
     meta: { pageTitle: "Qodana tests" },

--- a/dashboard/new-dashboard/tests/configurators/MachineConfigurator.test.ts
+++ b/dashboard/new-dashboard/tests/configurators/MachineConfigurator.test.ts
@@ -2,9 +2,9 @@ import { Observable } from "rxjs"
 import { expect, beforeEach, describe, it } from "vitest"
 import { DataQueryExecutor } from "../../src/components/common/DataQueryExecutor"
 import { BranchConfigurator, createBranchConfigurator } from "../../src/configurators/BranchConfigurator"
-import { MachineConfigurator } from "../../src/configurators/MachineConfigurator"
+import { getMachineGroupName, MACHINE_GROUP_QODANA_FLEET_HEAVY, MachineConfigurator } from "../../src/configurators/MachineConfigurator"
 import { TestMeasureConfigurator } from "../dummy/TestMeasureConfigurator"
-import { awaitMockCallsCount } from "../utils/awaitors"
+import { awaitCallbackTrue, awaitMockCallsCount } from "../utils/awaitors"
 import ConfiguratorTest, { ConfigurationTestData } from "./ConfiguratorTest"
 
 describe("Machine configurator", () => {
@@ -132,5 +132,68 @@ describe("Machine configurator", () => {
       await awaitMockCallsCount(data.fetchMock, 3)
       expect(data.fetchMock.mock.calls[2][0]).toBe(expected)
     })
+  })
+})
+
+describe("getMachineGroupName - qodana agents", () => {
+  const c5xlarge = "Linux EC2 c5.xlarge (4 vCPU, 8 GB)"
+
+  it("maps the new qodana fleet heavy agents to their own group", () => {
+    expect(getMachineGroupName("qodana-fleet-linux-amd64-heavy-test-i-00375d8f0e61ed132")).toBe(MACHINE_GROUP_QODANA_FLEET_HEAVY)
+  })
+
+  it("keeps legacy qodana heavy agents in the c5.xlarge group", () => {
+    expect(getMachineGroupName("qodana-linux-amd64-heavy-test-A-i-0a1b2c3d4e5f60718")).toBe(c5xlarge)
+  })
+
+  it("classifies fleet and legacy heavy agents into different groups", () => {
+    // Same group would collapse the group's common-prefix machine filter to `qodana-`,
+    // over-matching every other qodana machine class (see the query-layer test below).
+    expect(getMachineGroupName("qodana-fleet-linux-amd64-heavy-test-i-00375d8f0e61ed132")).not.toBe(getMachineGroupName("qodana-linux-amd64-heavy-test-A-i-0a1b2c3d4e5f60718"))
+  })
+
+  it("keeps qodana-aws-cpu-x64 agents in the c5a(d).xlarge group", () => {
+    expect(getMachineGroupName("qodana-aws-cpu-x64-i-0123456789abcdef0")).toBe("Linux EC2 c5a(d).xlarge (4 vCPU, 8 GB)")
+  })
+
+  it("returns Unknown for unmapped agents", () => {
+    expect(getMachineGroupName("some-unmapped-agent-i-000")).toBe("Unknown")
+  })
+})
+
+// Serialized fragment of a `machine LIKE 'qodana-fleet-linux-amd64-heavy…%'` filter. Its presence proves
+// the fleet group is queried by a fleet-only prefix; a merged fleet+heavy group would collapse to `qodana-%`.
+const FLEET_MACHINE_LIKE_FRAGMENT = '"f":"machine","v":"qodana-fleet-linux-amd64-heavy'
+const COLLAPSED_MACHINE_LIKE_FRAGMENT = '"f":"machine","v":"qodana-%"'
+
+describe("Machine configurator - qodana fleet group query", () => {
+  let data: ConfigurationTestData
+  let machineConfigurator: MachineConfigurator
+  let dataQueryExecutor: DataQueryExecutor
+
+  beforeEach(() => {
+    // A legacy heavy agent coexists with the fleet agents so the test proves the fleet group's filter
+    // stays fleet-specific instead of widening to also match the heavy class.
+    data = ConfiguratorTest.setupPreconditions([
+      "qodana-fleet-linux-amd64-heavy-test-i-0000aaaa",
+      "qodana-fleet-linux-amd64-heavy-test-i-0000bbbb",
+      "qodana-linux-amd64-heavy-test-A-i-0000cccc",
+    ])
+    machineConfigurator = new MachineConfigurator(data.serverConfigurator, data.persistenceForDashboard)
+    const measureConfigurator = new TestMeasureConfigurator()
+    dataQueryExecutor = new DataQueryExecutor([data.serverConfigurator, machineConfigurator, measureConfigurator])
+  })
+
+  it("filters the fleet group by a fleet-only prefix, never collapsing to qodana-", async () => {
+    dataQueryExecutor.subscribe(() => {})
+    // Wait until the loaded machine list has been grouped, so selecting the group hits the prefix path.
+    await awaitCallbackTrue(() => machineConfigurator.values.value.some((g) => g.value === MACHINE_GROUP_QODANA_FLEET_HEAVY))
+
+    machineConfigurator.selected.value = [MACHINE_GROUP_QODANA_FLEET_HEAVY]
+    await awaitCallbackTrue(() => data.fetchMock.mock.calls.some((c) => (c[0] as string).includes(FLEET_MACHINE_LIKE_FRAGMENT)))
+
+    const urls = data.fetchMock.mock.calls.map((c) => c[0] as string)
+    expect(urls.find((u) => u.includes(FLEET_MACHINE_LIKE_FRAGMENT))).toBeDefined()
+    expect(urls.find((u) => u.includes(COLLAPSED_MACHINE_LIKE_FRAGMENT))).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

The Qodana Tests dashboard (`/qodana/tests`) opens on an empty machine and renders blank charts, so JVM/.NET projects (e.g. Jenkins) can't be compared across `2026.1` / `2026.2` / `master`. The data is flowing for all branches — the gap is the machine dimension:

- Qodana's TeamCity agents were renamed to the fleet provisioner `qodana-fleet-linux-amd64-heavy-test-i-<instance>` — the majority of recent runs, and **all** of `master`'s. `getMachineGroupName()` had no rule for that prefix, so those agents fell into the catch-all `"Unknown"` group.
- The route hard-coded `initialMachine: "Linux EC2 c5a(d).xlarge (4 vCPU, 8 GB)"` (the old `qodana-aws-cpu-x64` agents), which now has **zero** rows on every branch.

So the dashboard defaulted to a dead machine.

## Fix

- `getMachineGroupName()` maps `qodana-fleet-linux-amd64-heavy*` to a new group `MACHINE_GROUP_QODANA_FLEET_HEAVY = "Linux EC2 c5.xlarge fleet (4 vCPU, 8 GB)"` (a shared exported constant, referenced by both the mapping and the route so they can't drift).
- The `/qodana/tests` route `initialMachine` points at that group, which has data on all three branches.
- `groupValues()` now `console.warn`s any machine that falls through to `"Unknown"` — the silent path that hid the fleet agents.

**Why a separate group and not merged into `"Linux EC2 c5.xlarge (4 vCPU, 8 GB)"`:** a selected machine group is queried by its members' longest-common-prefix as `machine LIKE '<prefix>%'`. Merging the `qodana-linux-amd64-heavy-*` and `qodana-fleet-linux-amd64-heavy-*` name-stems collapses that prefix to `qodana-`, which over-matches every other qodana machine class. The two pools are the same 4 vCPU / 8 GB hardware (metric values within ~1% for the same test), so this is purely to keep the query prefix tight.

## Tests

- `getMachineGroupName` unit tests: fleet, legacy heavy, `aws-cpu-x64`, and unmapped agents.
- Integration test: with a legacy heavy agent coexisting, the fleet group emits a fleet-only `LIKE` filter and never collapses to `qodana-%`.

Full vitest suite, `vue-tsc --noEmit`, and `oxlint` all pass.
