### PR TITLE
Ping PhpStorm dev group in unit-test degradation Slack alerts

### DIFF
--- a/pkg/degradation-detector/setting/unitTestsSettings.go
+++ b/pkg/degradation-detector/setting/unitTestsSettings.go
@@ -17,6 +17,11 @@ type teamConfig struct {
 	// AdditionalTestMetrics maps a test class name to extra metrics to assert alongside the
 	// default attempt.mean.ms. Values may be SQL LIKE patterns (e.g. "%.expected.%").
 	AdditionalTestMetrics map[string][]string
+	// Mention is an optional Slack mention prepended to this team's degradation messages.
+	// It only fires when the alert lands in this team's own SlackChannel (owner routing can send an
+	// alert elsewhere, in which case the ping is dropped). Use the raw Slack syntax, e.g.
+	// "<@U01ABC2DEF>" for a user or "<!subteam^S01ABC2DEF>" for a user group.
+	Mention string
 }
 
 var defaultUnitTestAnalysisSettings = detector.AnalysisSettings{
@@ -112,6 +117,7 @@ var teamConfigs = []teamConfig{
 			"com.jetbrains.php",
 		},
 		AnalysisSettings: degradationOnlyAnalysisSettings(),
+		Mention:          "<!subteam^S0BH689GW9G>", // @phpstorm-dev-duty
 	},
 	{
 		Team:         "lsp",
@@ -180,7 +186,7 @@ func GenerateAllUnitTestsSettings(backendUrl string, client *http.Client) []dete
 					Branch:           mainSettings.Branch,
 					Machine:          mainSettings.Machine,
 					Metric:           metric,
-					SlackSettings:    detector.SlackSettings{Channel: route.channel, ProductLink: "perfUnit"},
+					SlackSettings:    detector.SlackSettings{Channel: route.channel, ProductLink: "perfUnit", Mention: route.mention},
 					AnalysisSettings: route.analysisSettings,
 				},
 			})
@@ -195,6 +201,7 @@ type resolvedRoute struct {
 	channel               string
 	analysisSettings      detector.AnalysisSettings
 	additionalTestMetrics map[string][]string
+	mention               string
 }
 
 // resolveRoute determines where a test's notifications go and how it is analyzed.
@@ -205,6 +212,9 @@ type resolvedRoute struct {
 // Analysis settings and additional metrics always come from the matching package teamConfig
 // (so e.g. RubyMine/PhpStorm degradation-only analysis and debugger packet metrics are kept
 // regardless of which channel wins); they are independent of the channel decision.
+//
+// The mention also originates from the package teamConfig, but is a team-specific ping, so it is
+// dropped when owner routing redirects the alert away from that team's own channel.
 func resolveRoute(test string, projectOwners, ownerChannels map[string]string, configs []teamConfig) resolvedRoute {
 	teamCfg := matchTeamConfig(test, configs)
 
@@ -216,6 +226,7 @@ func resolveRoute(test string, projectOwners, ownerChannels map[string]string, c
 		route.channel = teamCfg.SlackChannel
 		route.analysisSettings = analysisSettingsOrDefault(teamCfg.AnalysisSettings)
 		route.additionalTestMetrics = teamCfg.AdditionalTestMetrics
+		route.mention = teamCfg.Mention
 	}
 
 	// Owner-based channel takes precedence over the package fallback.
@@ -223,6 +234,12 @@ func resolveRoute(test string, projectOwners, ownerChannels map[string]string, c
 		if channel := ownerChannels[owner]; channel != "" {
 			route.channel = channel
 		}
+	}
+
+	// A mention pings a team-specific group, so only keep it when the alert actually lands in that
+	// team's own channel. If owner routing redirected the alert elsewhere, drop the ping.
+	if teamCfg != nil && route.channel != teamCfg.SlackChannel {
+		route.mention = ""
 	}
 
 	return route

--- a/pkg/degradation-detector/setting/unitTestsSettings_test.go
+++ b/pkg/degradation-detector/setting/unitTestsSettings_test.go
@@ -27,17 +27,20 @@ func TestResolveRoute(t *testing.T) {
 	// one with additional metrics — enough to exercise every branch without depending on the real
 	// team/channel/package mappings. Passing it explicitly to resolveRoute keeps the test isolated
 	// from the production mapping data (and free of shared global state, so it can run in parallel).
+	const deltaMention = "<!subteam^SDELTA>"
 	configs := []teamConfig{
 		{Team: "alpha", SlackChannel: "alpha-channel", Packages: []string{"com.test.alpha"}},
 		{Team: "beta", SlackChannel: "beta-channel", Packages: []string{"com.test.beta"}, AnalysisSettings: degradationOnlyAnalysisSettings()},
 		{Team: "gamma", SlackChannel: "gamma-channel", Packages: []string{"com.test.gamma"}, AdditionalTestMetrics: map[string][]string{"com.test.gamma.PacketsTest": {"%.expected.%"}}},
+		{Team: "delta", SlackChannel: "delta-channel", Packages: []string{"com.test.delta"}, Mention: deltaMention},
 	}
 
 	const (
-		plainTest    = "com.test.alpha.SomeTest"
-		degradedTest = "com.test.beta.SomeTest"
-		metricsTest  = "com.test.gamma.PacketsTest"
-		unknownTest  = "com.test.unknown.SomeTest"
+		plainTest     = "com.test.alpha.SomeTest"
+		degradedTest  = "com.test.beta.SomeTest"
+		metricsTest   = "com.test.gamma.PacketsTest"
+		mentionedTest = "com.test.delta.SomeTest"
+		unknownTest   = "com.test.unknown.SomeTest"
 	)
 
 	tests := []struct {
@@ -48,6 +51,7 @@ func TestResolveRoute(t *testing.T) {
 		wantChannel    string
 		wantAnalysis   detector.AnalysisSettings
 		wantHasMetrics bool
+		wantMention    string
 	}{
 		{
 			name:         "no package match and no owner falls back to the catch-all channel",
@@ -108,6 +112,31 @@ func TestResolveRoute(t *testing.T) {
 			wantAnalysis:   defaultUnitTestAnalysisSettings,
 			wantHasMetrics: true,
 		},
+		{
+			name:         "mention is kept when the alert lands in the team's own channel via the package fallback",
+			test:         mentionedTest,
+			wantChannel:  "delta-channel",
+			wantAnalysis: defaultUnitTestAnalysisSettings,
+			wantMention:  deltaMention,
+		},
+		{
+			name:          "mention is kept when owner routing resolves to the team's own channel",
+			test:          mentionedTest,
+			projectOwners: map[string]string{mentionedTest: "delta-owner"},
+			ownerChannels: map[string]string{"delta-owner": "delta-channel"},
+			wantChannel:   "delta-channel",
+			wantAnalysis:  defaultUnitTestAnalysisSettings,
+			wantMention:   deltaMention,
+		},
+		{
+			name:          "mention is dropped when owner routing redirects the alert to another channel",
+			test:          mentionedTest,
+			projectOwners: map[string]string{mentionedTest: "delta-owner"},
+			ownerChannels: map[string]string{"delta-owner": "some-other-channel"},
+			wantChannel:   "some-other-channel",
+			wantAnalysis:  defaultUnitTestAnalysisSettings,
+			wantMention:   "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -116,6 +145,7 @@ func TestResolveRoute(t *testing.T) {
 			route := resolveRoute(tc.test, tc.projectOwners, tc.ownerChannels, configs)
 			assert.Equal(t, tc.wantChannel, route.channel)
 			assert.Equal(t, tc.wantAnalysis, route.analysisSettings)
+			assert.Equal(t, tc.wantMention, route.mention)
 			if tc.wantHasMetrics {
 				assert.NotEmpty(t, route.additionalTestMetrics)
 			} else {

--- a/pkg/degradation-detector/slack.go
+++ b/pkg/degradation-detector/slack.go
@@ -31,10 +31,23 @@ type SlackSettings struct {
 	// ProductLink is the part of the link on your dashboards after https://ij-perf.labs.jb.gg/.
 	// For example: intellij,ijent, kmt, clion
 	ProductLink string
+	// Mention is an optional Slack mention prepended to PerformanceSettings messages for this channel.
+	// Use the raw Slack syntax, e.g. "<@U01ABC2DEF>" for a user or "<!subteam^S01ABC2DEF>" for a user group.
+	// Note: only PerformanceSettings.CreateSlackMessage renders it today; wire mentionPrefix() into the
+	// Startup/Fleet builders if those paths ever need mentions.
+	Mention string
 }
 
 func (s SlackSettings) SlackChannel() string {
 	return s.Channel
+}
+
+// mentionPrefix returns the mention followed by a newline when a mention is configured, otherwise an empty string.
+func (s SlackSettings) mentionPrefix() string {
+	if s.Mention == "" {
+		return ""
+	}
+	return s.Mention + "\n"
 }
 
 func eventLink(tests string, build string, timestamp int64) string {
@@ -57,7 +70,7 @@ func (s PerformanceSettings) CreateSlackMessage(d Degradation) SlackMessage {
 	if s.Mode != "" {
 		mode = s.Mode
 	}
-	text := fmt.Sprintf(
+	text := s.mentionPrefix() + fmt.Sprintf(
 		"%sTest(s): %s\n"+
 			"Metric: %s\n"+
 			"Mode: %s\n"+


### PR DESCRIPTION
Add an optional Mention field to SlackSettings and prepend it to PerformanceSettings degradation messages. Add a matching Mention field to the unit-tests teamConfig and set it on the PhpStorm team so its degradation alerts in #phpstorm-performance-degradations ping the dev team user group

The mention originates from the package teamConfig but is a team-specific ping, so resolveRoute drops it when owner routing redirects the alert away from that team's own channel.