### PR TITLE
Revert "WSM Metrics: add new ModuleBridge related WSM metrics"

### DIFF
--- a/dashboard/new-dashboard/src/components/intelliJ/build-tools/jps/JpsImportPerformanceDashboardDevServer.vue
+++ b/dashboard/new-dashboard/src/components/intelliJ/build-tools/jps/JpsImportPerformanceDashboardDevServer.vue
@@ -69,8 +69,6 @@ const metricsDeclaration = [
   "jps.save.global.entities.ms",
   "jps.storage.jps.conf.reader.load.component.ms",
   "jps.module.dependency.index.workspace.model.listener.on.changed.ms",
-  "jps.modifiable.module.model.bridge.new.module.ms",
-  "jps.modifiable.module.model.bridge.load.module.ms",
 
   "workspaceModel.check.recursive.update.ms",
   "workspaceModel.collect.changes.ms",


### PR DESCRIPTION
This reverts commit bd04036fcff3848176eaca3e6018920c3aec341a.